### PR TITLE
finds powershell commands obfuscated by unicorn

### DIFF
--- a/yara/gen_unicorn_obfuscated_powershell.yar
+++ b/yara/gen_unicorn_obfuscated_powershell.yar
@@ -1,0 +1,24 @@
+rule gen_unicorn_obfuscated_powershell
+{
+    meta: 
+        description = "PowerShell payload obfuscated by Unicorn toolkit"
+        author = "John Lambert @JohnLaTwC"
+        date = "2018-03-07"
+        hash = "b93d2fe6a671a6a967f31d5b3a0a16d4f93abcaf25188a2bbdc0894087adb10d"
+        reference = "https://github.com/trustedsec/unicorn/"
+    strings:
+        $h1 = "powershell"
+        $footer = /('"|'\)")/
+        $s1 = ".value.toString()" 
+        $s2 = "-w 1" 
+        $p1 = /;sv \w{1,3} \w{1,3};/ 
+        $p2 = /;s'*v ['|\w]{1,4} ['|\w]{1,4};/ 
+        $b64 = /'JAB[a-zA-Z0-9=+\/]{50,}/
+    condition:
+        filesize < 20KB
+        and $h1 at 0
+        and @footer[1] > (filesize - 5)
+        and all of ($s*)
+        and #b64 == 1
+        and 1 of ($p*)
+}

--- a/yara/gen_unicorn_obfuscated_powershell.yar
+++ b/yara/gen_unicorn_obfuscated_powershell.yar
@@ -1,6 +1,5 @@
-rule gen_unicorn_obfuscated_powershell
-{
-    meta: 
+rule gen_unicorn_obfuscated_powershell {
+    meta:
         description = "PowerShell payload obfuscated by Unicorn toolkit"
         author = "John Lambert @JohnLaTwC"
         date = "2018-03-07"
@@ -8,17 +7,15 @@ rule gen_unicorn_obfuscated_powershell
         reference = "https://github.com/trustedsec/unicorn/"
     strings:
         $h1 = "powershell"
-        $footer = /('"|'\)")/
-        $s1 = ".value.toString()" 
-        $s2 = "-w 1" 
-        $p1 = /;sv \w{1,3} \w{1,3};/ 
-        $p2 = /;s'*v ['|\w]{1,4} ['|\w]{1,4};/ 
-        $b64 = /'JAB[a-zA-Z0-9=+\/]{50,}/
+        $s1 = ".value.toString() 'JAB"
+        $s2 = "-w 1 -C \"sv"
     condition:
         filesize < 20KB
+        and uint32be(0) == 0x706f7765
         and $h1 at 0
-        and @footer[1] > (filesize - 5)
+        and (
+           uint16be(filesize-2) == 0x2722 or  /* Footer 1 */
+           ( uint16be(filesize-2) == 0x220a and uint8(filesize-3) == 0x27 )  /* Footer 2 */
+        )
         and all of ($s*)
-        and #b64 == 1
-        and 1 of ($p*)
 }


### PR DESCRIPTION
I see unicorn samples uploaded to VT a few times a day. Here is a rule for it. 
Unicorn toolkit: https://github.com/trustedsec/unicorn/

Example hashes:
14c708d8577eafc56fa8af4d45aaedfbba185aee6ffc22650b2b5b4a58c6ae0f
19c8d44fe80cfbd61e30f9aeef3f7433473e6ae66d7b2e26bae22ed9b338a755
1f1990d08ae6ac2480e2ba4fcc4f00105aa2eb8606fa5b23be450922a705a637
211c690cded91446b43ec2bd89a8071df8b96442b3fa9762a91945c8987996db
4b877196a90b2ad62fe795fff63d36742d9099ae677fe5e44ef47e6a9919adc4
5239c2de70c82b70ce3dac0669b4b4ec95b5d5fd0286bad8e3ec960217e20627

Also https://twitter.com/JohnLaTwC/status/971536587388407809