### PR TITLE
gen_bad_pdf.yar: fix detection of Metasploit generated files

### DIFF
--- a/yara/gen_bad_pdf.yar
+++ b/yara/gen_bad_pdf.yar
@@ -8,7 +8,8 @@ rule SUSP_Bad_PDF {
    strings:
       $s1 = "         /F (http//" ascii
       $s2 = "         /F (\\\\\\\\" ascii
-      $s3 = "<</F (\\\\" ascii
+      $s3 = "        /F (\\\\\\\\" ascii
+      $s4 = "<</F (\\\\" ascii
    condition:
       ( uint32(0) == 0x46445025 or uint32(0) == 0x4450250a ) and 1 of them
 }

--- a/yara/gen_bad_pdf.yar
+++ b/yara/gen_bad_pdf.yar
@@ -7,9 +7,8 @@ rule SUSP_Bad_PDF {
       hash1 = "d8c502da8a2b8d1c67cb5d61428f273e989424f319cfe805541304bdb7b921a8"
    strings:
       $s1 = "         /F (http//" ascii
-      $s2 = "         /F (\\\\\\\\" ascii
-      $s3 = "        /F (\\\\\\\\" ascii
-      $s4 = "<</F (\\\\" ascii
+      $s2 = "        /F (\\\\\\\\" ascii
+      $s3 = "<</F (\\\\" ascii
    condition:
       ( uint32(0) == 0x46445025 or uint32(0) == 0x4450250a ) and 1 of them
 }


### PR DESCRIPTION
Metasploit "badpdf" module generates files that are not detected by this rule. This happens in the case of newly generated files, using the `FILENAME` option in MSF. Existing PDF files that are injected, with the `PDFINJECT` option, are properly detected.
The reason is that the interesting line begins with 8 space characters, instead of 9 as in the current rule. See: https://github.com/rapid7/metasploit-framework/blob/master/modules/auxiliary/fileformat/badpdf.rb#L123


Without the patch, MSF generated files are not detected.
After the patch, they are detected.

The patch keeps the current pattern, with 9 spaces, and adds a new one with 8 spaces.
But, maybe a more robust/generic pattern could be written?