### PR TITLE
Added rules for a tiny webshell and a go based htran variant

### DIFF
--- a/yara/thor-hacktools.yar
+++ b/yara/thor-hacktools.yar
@@ -4556,3 +4556,22 @@ rule HKTL_NoPowerShell {
    condition:
       1 of them
 }
+
+rule htran_go {
+	meta:
+		author = "Jeff Beley"
+		hash1 = "4acbefb9f7907c52438ebb3070888ddc8cddfe9e3849c9d0196173a422b9035f"
+		description = "detects go based htran variant"
+		date = "2019-01-09"
+
+
+	strings:
+		$s1 = "https://github.com/cw1997/NATBypass" fullword ascii
+		$s2 = "-slave ip1:port1 ip2:port2" fullword ascii
+		$s3 = "optional argument:" fullword ascii
+		$s4 = "-tran port1 ip:port2" fullword ascii
+	condition:
+		uint16(0) == 0x5a4d and filesize < 7000KB and all of them
+}
+
+

--- a/yara/thor-hacktools.yar
+++ b/yara/thor-hacktools.yar
@@ -4556,22 +4556,16 @@ rule HKTL_NoPowerShell {
    condition:
       1 of them
 }
-
-rule htran_go {
-	meta:
-		author = "Jeff Beley"
-		hash1 = "4acbefb9f7907c52438ebb3070888ddc8cddfe9e3849c9d0196173a422b9035f"
-		description = "detects go based htran variant"
-		date = "2019-01-09"
-
-
-	strings:
-		$s1 = "https://github.com/cw1997/NATBypass" fullword ascii
-		$s2 = "-slave ip1:port1 ip2:port2" fullword ascii
-		$s3 = "optional argument:" fullword ascii
-		$s4 = "-tran port1 ip:port2" fullword ascii
-	condition:
-		uint16(0) == 0x5a4d and filesize < 7000KB and all of them
+rule HKTL_htran_go {
+   meta:
+      author = "Jeff Beley"
+      hash1 = "4acbefb9f7907c52438ebb3070888ddc8cddfe9e3849c9d0196173a422b9035f"
+      description = "Detects go based htran variant"
+      date = "2019-01-09"
+   strings:
+      $s1 = "https://github.com/cw1997/NATBypass" fullword ascii
+      $s2 = "-slave ip1:port1 ip2:port2" fullword ascii
+      $s3 = "-tran port1 ip:port2" fullword ascii
+   condition:
+      uint16(0) == 0x5a4d and filesize < 7000KB and 1 of them
 }
-
-

--- a/yara/thor-webshells.yar
+++ b/yara/thor-webshells.yar
@@ -9319,3 +9319,20 @@ rule WebShell_JexBoss_WAR_1 {
    condition:
       uint16(0) == 0x4b50 and filesize < 4KB and 1 of them
 }
+
+rule webshell_tinyasp
+{
+
+    meta:
+		author = "Jeff Beley"
+		hash1 = "1f29905348e136b66d4ff6c1494d6008ea13f9551ad5aa9b991893a31b37e452"
+		description = "detects 24 byte ASP webshell and variations"
+		date = "2019-01-09"
+
+    strings:
+        $a = "Execute Request"
+
+     condition:
+            all of them and filesize < 200
+
+}

--- a/yara/thor-webshells.yar
+++ b/yara/thor-webshells.yar
@@ -9320,19 +9320,14 @@ rule WebShell_JexBoss_WAR_1 {
       uint16(0) == 0x4b50 and filesize < 4KB and 1 of them
 }
 
-rule webshell_tinyasp
-{
-
+rule webshell_tinyasp {
     meta:
-		author = "Jeff Beley"
-		hash1 = "1f29905348e136b66d4ff6c1494d6008ea13f9551ad5aa9b991893a31b37e452"
-		description = "detects 24 byte ASP webshell and variations"
-		date = "2019-01-09"
-
-    strings:
-        $a = "Execute Request"
-
-     condition:
-            all of them and filesize < 200
-
+	author = "Jeff Beley"
+	hash1 = "1f29905348e136b66d4ff6c1494d6008ea13f9551ad5aa9b991893a31b37e452"
+	description = "Detects 24 byte ASP webshell and variations"
+	date = "2019-01-09"
+   strings:
+   	$s1 = "Execute Request" ascii wide nocase
+   condition:
+   	uint16(0) == 0x253c and filesize < 150 and 1 of them
 }


### PR DESCRIPTION
Added rules for a tiny webshell and a go based htran variant [https://github.com/cw1997/NATBypass](https://github.com/cw1997/NATBypass)