### PR TITLE
typo was causing build-rules.py to fail

### DIFF
--- a/iocs/filename-iocs.txt
+++ b/iocs/filename-iocs.txt
@@ -1836,7 +1836,7 @@ Temp\\rad[A-F0-9]{5}\.exe;70
 \\sfmsc\.exe;60
 \\dnslookup\.exe;60
 \\iissrv\.exe;60
-\\regsys\.exe ;60
+\\regsys\.exe;60
 \\smbinit\.exe;60
 
 # Unicode Left-to-Right Override Trick https://goo.gl/cHnBqP

--- a/iocs/filename-iocs.txt
+++ b/iocs/filename-iocs.txt
@@ -1836,7 +1836,7 @@ Temp\\rad[A-F0-9]{5}\.exe;70
 \\sfmsc\.exe;60
 \\dnslookup\.exe;60
 \\iissrv\.exe;60
-\\regsys.\exe ;60
+\\regsys\.exe ;60
 \\smbinit\.exe;60
 
 # Unicode Left-to-Right Override Trick https://goo.gl/cHnBqP


### PR DESCRIPTION
validated fixed after this change. 

INFO:root:Compiling Filename IOCs from filename-iocs.txt
Traceback (most recent call last):
  File "build-rules.py", line 132, in initialize_filename_iocs
    fioc = {'regex': re.compile(regex), 'score': score, 'description': desc, 'regex_fp': regex_fp_comp}
  File "/usr/lib64/python3.6/re.py", line 233, in compile
    return _compile(pattern, flags)
  File "/usr/lib64/python3.6/re.py", line 301, in _compile
    p = sre_compile.compile(pattern, flags)
  File "/usr/lib64/python3.6/sre_compile.py", line 562, in compile
    p = sre_parse.parse(p, flags)
  File "/usr/lib64/python3.6/sre_parse.py", line 855, in parse
    p = _parse_sub(source, pattern, flags & SRE_FLAG_VERBOSE, 0)
  File "/usr/lib64/python3.6/sre_parse.py", line 416, in _parse_sub
    not nested and not items))
  File "/usr/lib64/python3.6/sre_parse.py", line 502, in _parse
    code = _escape(source, this, state)
  File "/usr/lib64/python3.6/sre_parse.py", line 401, in _escape
    raise source.error("bad escape %s" % escape, len(escape))
sre_constants.error: bad escape \e at position 9
ERROR:root:Error reading line: \\regsys.\exe ;60