### PR TITLE
Added gen_webshells.yar to detect multiple different PHP webshells

### DIFF
--- a/yara/gen_webshells.yar
+++ b/yara/gen_webshells.yar
@@ -1,0 +1,30 @@
+import "math"
+
+rule php_obfuscated   {
+
+meta:
+        author = "Jeff Beley"
+        description = "Detects base64 obfuscated php webshells"
+        date = "2019-11-02"
+
+strings:
+        $a1 = "<?"
+        $a4 = /[A-Za-z0-9+\/=]{50,}/
+        $bad = "abcdefghijklmnopqrstuvwxyz"
+        $p1 = "create_function" ascii wide nocase
+        $p2 = "str_replace" ascii wide nocase
+        $p3 = "base64_decode" ascii wide nocase
+        $p4 = "gzinflate" ascii wide nocase
+        $p5 = "eval" ascii wide nocase
+        $p6 = "strrev" ascii wide nocase
+        $p7 = "str_rot13" ascii wide nocase
+        $p8 = "rawurldecode" ascii wide nocase
+        $p9 = "gzuncompress" ascii wide nocase
+
+condition:
+        $a1
+        and
+		math.entropy(0, filesize) >=  4
+        and not $bad
+        and 1 of ($p*,$a4)
+}


### PR DESCRIPTION
Creation of rule to detect potentially obfuscated PHP webshells. Also detects non-obfsucated webshells.

After cloning [tennc's webshell repo](https://github.com/tennc/webshell)

```
yara -rfw -p 18 gen_webshells.yar /home/jbeley/Sources/webshell/ |wc -l
578
```

Sample output:

```
php_obfuscated /home/jbeley/Sources/webshell//net-friend/ChatRoom/菊花聊天室.php
0x7c:$a1: <?
0xe0:$p2: str_replace
php_obfuscated /home/jbeley/Sources/webshell//net-friend/asp/google.jpg
0x3dd8:$a1: <?
0x92:$p5: eval
php_obfuscated /home/jbeley/Sources/webshell//net-friend/php/零魂PHP一句话木马客户端%28一键提交版%29/零魂PHP一句话木马客户端(一键提交版)/Readme.txt
0x46:$a1: <?
0x4c:$p5: eval
````

I realize that the `$a4` regex is expensive, but this rule has been very effective at finding PHP webshells. 