### PR TITLE
Update gen_python_pyminifier_encoded_payload.yar

### DIFF
--- a/yara/gen_python_pyminifier_encoded_payload.yar
+++ b/yara/gen_python_pyminifier_encoded_payload.yar
@@ -17,7 +17,7 @@ rule gen_python_pyminifier_encoded_payload
         hash = "b454179c13cb4727ae06cc9cd126c3379e2aded5c293af0234ac3312bf9bdad2"
 
     strings:
-        $s1 = "exec(zlib.decompress(base64.b64decode('eJy"
+        $s1 = "exec(zlib.decompress(base64.b64decode('eJ"
         $s2 = "base64" fullword
         $s3 = "zlib" fullword
 


### PR DESCRIPTION
tweak rule slightly to catch more cases:
15d201152a9465497a0f9dd6939e48315b358702c5e2a3c506ad436bb8816da7
5c5c1b5c6a5d7eff3941040321fde425eca612e870bba553f22ae5f9a2bd3318
d5664c70f3543f306f765ea35e22829dbea66aec729e8e11edea9806d0255b7e