### PR TITLE
Simplify xor usage in rules

### DIFF
--- a/yara/gen_susp_xor.yar
+++ b/yara/gen_susp_xor.yar
@@ -8,14 +8,10 @@ rule SUSP_XORed_URL_in_EXE {
       date = "2020-03-09"
       score = 50
    strings:
-      $s1 = "http://" xor
-      $s2 = "https://" xor
-      $f1 = "http://" ascii
-      $f2 = "https://" ascii
+      $s1 = "http://" xor(0x01-0xff)
+      $s2 = "https://" xor(0x01-0xff)
    condition:
       uint16(0) == 0x5a4d and
-      filesize < 2000KB and (
-         ( $s1 and #s1 > #f1 ) or
-         ( $s2 and #s2 > #f2 )
-      )
+      filesize < 2000KB and
+         ($s1 or $s2)
 }

--- a/yara/gen_xor_hunting.yar
+++ b/yara/gen_xor_hunting.yar
@@ -24,7 +24,7 @@ rule SUSP_XORed_MSDOS_Stub_Message {
       $xo1 = "This program cannot be run in DOS mode" xor ascii wide
       $xo2 = "This program must be run under Win32" xor ascii wide
       $xof1 = "This program cannot be run in DOS mode" ascii wide
-      $xof2 = "This program must be run under Win32" xor ascii wide
+      $xof2 = "This program must be run under Win32" ascii wide
    condition:
       1 of ($xo*) and not 1 of ($xof*)
 }

--- a/yara/gen_xor_hunting.yar
+++ b/yara/gen_xor_hunting.yar
@@ -7,10 +7,9 @@ rule SUSP_XORed_Mozilla {
       date = "2019-10-28"
       score = 65
    strings:
-      $xo1 = "Mozilla/5.0" xor ascii wide
-      $xof1 = "Mozilla/5.0" ascii wide
+      $xo1 = "Mozilla/5.0" xor(0x01-0xff) ascii wide
    condition:
-      $xo1 and not $xof1
+      $xo1
 }
 
 rule SUSP_XORed_MSDOS_Stub_Message {
@@ -21,10 +20,8 @@ rule SUSP_XORed_MSDOS_Stub_Message {
       date = "2019-10-28"
       score = 55
    strings:
-      $xo1 = "This program cannot be run in DOS mode" xor ascii wide
-      $xo2 = "This program must be run under Win32" xor ascii wide
-      $xof1 = "This program cannot be run in DOS mode" ascii wide
-      $xof2 = "This program must be run under Win32" ascii wide
+      $xo1 = "This program cannot be run in DOS mode" xor(0x01-0xff) ascii wide
+      $xo2 = "This program must be run under Win32" xor(0x01-0xff) ascii wide
    condition:
-      1 of ($xo*) and not 1 of ($xof*)
+      1 of ($xo*)
 }


### PR DESCRIPTION
This PR simplifies the usage of the xor-modifier.

Instead of searching for all xor variants, using the `xor(min-max)` syntax should increase performance and make the rules more readable.

Especially `SUSP_XORed_MSDOS_Stub_Message` is expected to match on more files now, since files containing the stub text in xored and non-xored variant will hit now, too.