### PR TITLE
Detection for CVE-2021-27055 activity

### DIFF
--- a/yara/apt_hafnium_log_sigs.yar
+++ b/yara/apt_hafnium_log_sigs.yar
@@ -59,3 +59,17 @@ rule LOG_Exchange_Forensic_Artefacts_CleanUp_Activity_Mar21_1 : LOG {
    condition:
       1 of ($x*) or 2 of them
 }
+
+rule EXPL_LOG_CVE_2021_27055_Exchange_Forensic_Artefacts : LOG {
+   meta:
+	  description = "Detects suspicious log entries that indicate requests as described in reports on HAFNIUM activity. Scan logs in \\Microsoft\\Exchange Server\\V15\\Logging\\HttpProxy\\"
+	  author = "Zach Stanford - @svch0st"
+	  reference = "https://www.microsoft.com/security/blog/2021/03/02/hafnium-targeting-exchange-servers/#scan-log"
+	  date = "2021-03-10"
+	  score = 65
+   strings:
+	  $s1 = "ServerInfo" ascii wide fullword
+	  $r1 = /(ecp|owa)\/auth\/\w\.js/
+   condition:
+	  2 of them
+}


### PR DESCRIPTION
CVE-2021-27055 activity found in HTTP Proxy logs @ \Microsoft\Exchange Server\V15\Logging\HttpProxy\.

Example Snippet:
`2021-03-07T15:04:04.546Z,1a51fb75-2f6f-4a40-8129-ff80098494a0,15,0,1395,0,,Owa,[REDACTED],/owa/auth/x.js,,FBA,false,,,ServerInfo~localhost/ecp/default.flt?,Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML  like Gecko) Chrome/69.0.3497.81 Safari/537.36,[REDACTED],[REDACTED],500,500,,GET,Proxy,localhost,0.00.0003.000,CrossRegion,X-AnonResource-Backend-Cookie,,,,0,85,1,,1,7,,0,,0,,0,0,,0,382,0,,,,239,4,4,3,,2,380,1,298,131,135,136,382,,,,BeginRequest=2021-03-07T15:04:04.167Z;CorrelationID=<empty>;ProxyState-Run=None;FEAuth=BEVersion-3;ProxyToDownLevel=True;NewConnection=::1&0;BeginGetResponse=2021-03-07T15:04:04.245Z;OnResponseReady=2021-03-07T15:04:04.484Z;EndGetResponse=2021-03-07T15:04:04.484Z;ProxyState-Complete=ProxyResponseData;EndRequest=[REDACTED]`

