### PR TITLE
Assemble and publish Yara rules through GitHub Workflows

### DIFF
--- a/.github/workflows/yara-assemble.yml
+++ b/.github/workflows/yara-assemble.yml
@@ -1,0 +1,31 @@
+# This workflow assembles all Yara rules into a single file
+
+name: Assemble Yara
+
+on:
+  push:
+    branches:
+      - master
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - name: Check-out the repository
+        uses: actions/checkout@v2
+
+      # Assemble all *.yar files (except those requiring external variables)
+      - name: Assemble all Yara files
+        run: "for f in $GITHUB_WORKSPACE/yara/*.yar; do if [[ (\"${f##*/}\" != \"generic_anomalies.yar\") && (\"${f##*/}\" != \"general_cloaking.yar\") && (\"${f##*/}\" != \"thor_inverse_matches.yar\") && (\"${f##*/}\" != \"yara_mixed_ext_vars.yar\") ]]; then cat $f >> signature-base.yar; fi;done"
+
+      # Upload the assembled Yara artifact
+      - name: Upload the resulting Yara artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: signature-base.yar
+          path: signature-base.yar


### PR DESCRIPTION
This PR introduces a GitHub Workflow which assembles all standalone Yara rules (not requiring external variables) into a single Yara file available as a download from the Workflow's Artifacts.

When downloading all Yara rules contained within the signature base, the Yara CLI still requires each file to be passed as an argument. While Linux allows the `*` character to serve as expansion, Windows requires some scripting to achieve a similar result. This PR leverages the GitHub Workflows to provide a single Yara file containing all standalone rules, sparing analysts a few seconds of repetitive scripting.

This behavior was inspired from [Malpedia's `GET /api/get/yara/auto/raw` endpoint](https://malpedia.caad.fkie.fraunhofer.de/usage/api#apigetyaraautoraw) which provides a similar useful feature.

Do note that Workflow Artificats are only available for signed-in users. A similar behavior could alternatively be achieved by having a Workflow make automated releases.