### PR TITLE
Update apt_cobaltstrike_evasive.yar

### DIFF
--- a/yara/apt_cobaltstrike_evasive.yar
+++ b/yara/apt_cobaltstrike_evasive.yar
@@ -16,9 +16,9 @@ rule CobaltStrike_Sleep_Decoder_Indicator {
 	meta:
 		description = "Detects CobaltStrike sleep_mask decoder"
 		author = "yara@s3c.za.net"
-		date = "2019-08-16"
+		date = "2021-07-19"
 	strings:
-		$sleep_decoder = {8B 07 8B 57 04 83 C7 08 85 C0 75 2C}
+		$sleep_decoder = { 48 89 5C 24 08 48 89 6C 24 10 48 89 74 24 18 57 48 83 EC 20 4C 8B 51 08 41 8B F0 48 8B EA 48 8B D9 45 8B 0A 45 8B 5A 04 4D 8D 52 08 45 85 C9 }
 	condition:
 		$sleep_decoder
 }


### PR DESCRIPTION
Confirmed working with CS 4.1 and 4.3, works with both sleep_mask and obfuscate set in C2 config. None of the other rules in signature-base catch this at the moment.