### PR TITLE
cve_2021_26084_confluence multiline condition

### DIFF
--- a/yara/expl_cve_2021_26084_confluence_log.yar
+++ b/yara/expl_cve_2021_26084_confluence_log.yar
@@ -17,7 +17,7 @@ rule LOG_EXPL_Confluence_RCE_CVE_2021_26084_Sep21 : LOG {
 
       $sc1 = " ERROR "
       $sc2 = " | userName: anonymous | action: createpage-entervariables"
-      $sc3 = "[confluence.plugins.synchrony.SynchronyContextProvider] getContextMap -- url: /pages/createpage-entervariables.action"
+      $re1 = /\[confluence\.plugins\.synchrony\.SynchronyContextProvider\] getContextMap (\n )?-- url: \/pages\/createpage-entervariables\.action/
    condition:
-      1 of ($x*) or ( $sa1 and 1 of ($sb*) ) or all of ($sc*)
+      1 of ($x*) or ( $sa1 and 1 of ($sb*) ) or (all of ($sc*) and $re1)
 }


### PR DESCRIPTION
Tested with CrowdResponse on an exploited server.
Reason : logging on standard Confluence install was multiline.

Note: the `\n` option on the YARa documentation for ASCII string does not work with Engine.