### PR TITLE
fix: Bigger Filesize for more matches

### DIFF
--- a/yara/expl_proxyshell.yar
+++ b/yara/expl_proxyshell.yar
@@ -41,7 +41,7 @@ rule WEBSHELL_ASPX_ProxyShell_Aug21_2 {
       $s1 = "Page Language=" ascii nocase
    condition:
       uint32(0) == 0x4e444221 /* PST header: !BDN */
-      and filesize < 350KB
+      and filesize < 2MB
       and $s1
 }
 
@@ -58,6 +58,21 @@ rule WEBSHELL_ASPX_ProxyShell_Aug21_3 {
       uint16(0) == 0x8230 /* DER start */
       and filesize < 10KB
       and $s1
+}
+
+rule WEBSHELL_ASPX_ProxyShell_Sep21_1 { 
+   meta:
+      description = "Detects webshells dropped by ProxyShell exploitation based on their file header (must be PST) and base64 decoded request"
+      author = "Tobias Michalski"
+      date = "2021-09-17"
+      reference = "Internal Research"
+      hash = "219468c10d2b9d61a8ae70dc8b6d2824ca8fbe4e53bbd925eeca270fef0fd640"
+      score = 75
+   strings:
+      $s = ".FromBase64String(Request["
+   condition:
+      uint32(0) == 0x4e444221
+      and any of them
 }
 
 rule APT_IIS_Config_ProxyShell_Artifacts {


### PR DESCRIPTION
Setting the filesize condition bigger does not seem to increase the FP rate, but increases the range of matches.