### PR TITLE
Fix Firefox.exe size FP

### DIFF
--- a/yara/generic_anomalies.yar
+++ b/yara/generic_anomalies.yar
@@ -131,7 +131,15 @@ rule Suspicious_Size_firefox_exe {
     condition:
         uint16(0) == 0x5a4d
         and filename == "firefox.exe"
-        and ( filesize < 265KB or filesize > 910KB )
+        and (
+        	(
+        		filepath not contains "Tor Browser"
+        		and ( filesize < 265KB or filesize > 910KB )
+        	) or (
+        		filepath contains "Tor Browser"
+        		and ( filesize < 265KB or filesize > 1800KB )
+        	)
+        )	
 }
 
 rule Suspicious_Size_java_exe {

--- a/yara/generic_anomalies.yar
+++ b/yara/generic_anomalies.yar
@@ -133,7 +133,7 @@ rule Suspicious_Size_firefox_exe {
         and filename == "firefox.exe"
         and (
         	(
-        		filepath not contains "Tor Browser"
+        		not filepath contains "Tor Browser"
         		and ( filesize < 265KB or filesize > 910KB )
         	) or (
         		filepath contains "Tor Browser"


### PR DESCRIPTION
Tor browser was creating FPs in the firefox_size rule, added option to check for path containing "tor browser"