### PR TITLE
Change lower limit on filesize to 1000 from 1300

### DIFF
--- a/yara/crime_socgholish.yar
+++ b/yara/crime_socgholish.yar
@@ -14,7 +14,7 @@ rule MAL_ZIP_SocGholish_Mar21_1 : zip js socgholish {
         $b1 = "Firefox.js" ascii
         $b2 = "Edge.js" ascii
     condition:
-        uint16(0) == 0x4b50 and filesize > 1300 and filesize < 1600 and (
+        uint16(0) == 0x4b50 and filesize > 1000 and filesize < 1600 and (
             2 of ($a*) or
             any of ($b*)
         )


### PR DESCRIPTION
For rule MAL_ZIP_SocGholish_Mar21_1 : zip js socgholish. Seeing a significant number of samples in VirusTotal that are smaller than 1300. No noticeable increase in false positives. 333 results from 2021-05-18 to 2021-11-15 with the new filesize lower limit. Approximately 10 of these go above the previous 1300 lower limit and would have been detected previously.