### PR TITLE
Remove lower limit on file size for SocGholish zip

### DIFF
--- a/yara/crime_socgholish.yar
+++ b/yara/crime_socgholish.yar
@@ -14,7 +14,7 @@ rule MAL_ZIP_SocGholish_Mar21_1 : zip js socgholish {
         $b1 = "Firefox.js" ascii
         $b2 = "Edge.js" ascii
     condition:
-        uint16(0) == 0x4b50 and filesize > 1000 and filesize < 1600 and (
+        uint16(0) == 0x4b50 and filesize < 1600 and (
             2 of ($a*) or
             any of ($b*)
         )


### PR DESCRIPTION
Starting about 3 weeks ago, newly submitted samples in Virus Total have started coming in at less than 1000 bytes. No known false positives when the lower limit is removed.
Example: https://www.virustotal.com/gui/file/f007fbf2a8045194fc2558109810bebe12e584ac22e233995bc7d8e553a325b3