### PR TITLE
New YARA rule for fake update JS files.

### DIFF
--- a/yara/crime_socgholish.yar
+++ b/yara/crime_socgholish.yar
@@ -44,3 +44,24 @@ rule MAL_JS_SocGholish_Mar21_1 : js socgholish {
     condition:
         $try in (0 .. 10) and filesize > 3KB and filesize < 5KB and 8 of ($s*)
 }
+
+rule SocGholish_JS_22_02_2022 {
+    meta:
+        description = "Detects SocGholish fake update Javascript files 22.02.2022"
+        author = "Wojciech Cieślak"
+        date = "2022-02-22"
+        hash = "3e14d04da9cc38f371961f6115f37c30"
+        hash = "dffa20158dcc110366f939bd137515c3"
+        hash = "afee3af324951b1840c789540d5c8bff"
+        hash = "c04a1625efec27fb6bbef9c66ca8372b"
+        hash = "d08a2350df5abbd8fd530cff8339373e"
+    
+    strings:
+        $s1 = " + encodeURIComponent(''+" ascii
+        $s2 = "['open']('POST'," ascii 
+        $s3 = "new ActiveXObject('MSXML2.XMLHTTP');" ascii
+    
+    condition:
+        filesize < 5KB and all of them
+}
+


### PR DESCRIPTION
Recent SocGholish fake updates JS files does not trigger rule MAL_JS_SocGholish_Mar21_1 e.g https://www.virustotal.com/gui/file/2e63faed2569ba73a691832951b92ca8e14c938df750ce0798d3ff7741fa37fe

Key changes:
- obfuscated eval and sleep calls
- size below 3KB
- no script deletion 
- missing some other strings highlighted in the rule

Proposed rule triggers on recent files as well as on older mentioned in the MAL_JS_SocGholish_Mar21_1 meta information. 

No FPs in Virustotal in content searches for the last 90 days.