### PR TITLE
Added webshell_csharp_hash_regex

### DIFF
--- a/yara/gen_webshell_csharp.yar
+++ b/yara/gen_webshell_csharp.yar
@@ -1,0 +1,24 @@
+
+rule WEBSHELL_Csharp_Hash_String_Oct22 {
+	meta:
+		description = "C# webshell using specific hash check for the password."
+		license = "Detection Rule License 1.1 https://github.com/Neo23x0/signature-base/blob/master/LICENSE"
+		author = "Nils Kuhnert (modified by Florian Roth)"
+		hash = "29c187ad46d3059dc25d5f0958e0e8789fb2a51b9daaf90ea27f001b1a9a603c"
+		date = "2022-10-27"
+		score = 60
+	strings:
+		$gen1 = "void Page_Load" ascii
+		$gen2 = "FromBase64String" ascii
+		$gen3 = "CryptoServiceProvider" ascii
+		$gen4 = "ComputeHash" ascii
+
+		$hashing1 = "BitConverter.ToString(" ascii /* Webshell uses ToString from a string: BitConverter.ToString(ptqVQ) */
+		$hashing2 = ").Replace(\"-\", \"\") == \"" ascii
+
+      $filter1 = "BitConverter.ToString((" ascii /* Usually it's something like: return ((BitConverter.ToString((new SHA1CryptoServiceProvider() */
+	condition:
+		filesize < 10KB 
+		and all of ($gen*) and all of ($hashing*)
+		and not 1 of ($filter*)
+}

--- a/yara/gen_webshells.yar
+++ b/yara/gen_webshells.yar
@@ -6075,3 +6075,23 @@ rule webshell_in_image
 		) ) )
 }
 
+rule webshell_csharp_hash_regex {
+	meta:
+		description = "C# webshell using specific hash check for the password."
+		license = "Detection Rule License 1.1 https://github.com/Neo23x0/signature-base/blob/master/LICENSE"
+		author = "Nils Kuhnert"
+		hash = "29c187ad46d3059dc25d5f0958e0e8789fb2a51b9daaf90ea27f001b1a9a603c"
+		date = "2022-10-27"
+		score = 55
+	strings:
+		$gen1 = "void Page_Load" ascii wide
+		$gen2 = "HttpContext.Current.Request.Form" ascii wide
+		$gen3 = "HttpContext.Current.Request.Files" ascii wide
+		$gen4 = "FromBase64String" ascii wide
+
+		$hashing1 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{32}"\)/ ascii wide
+		$hashing2 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{40}"\)/ ascii wide
+		$hashing3 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{64}"\)/ ascii wide
+	condition:
+		all of ($gen*) and 1 of ($hashing*)
+}

--- a/yara/gen_webshells.yar
+++ b/yara/gen_webshells.yar
@@ -6085,9 +6085,9 @@ rule webshell_csharp_hash_regex {
 		score = 55
 	strings:
 		$gen1 = "void Page_Load" ascii wide
-		$gen2 = "HttpContext.Current.Request.Form" ascii wide
-		$gen3 = "HttpContext.Current.Request.Files" ascii wide
-		$gen4 = "FromBase64String" ascii wide
+		$gen2 = "FromBase64String" ascii wide
+		$gen3 = "CryptoServiceProvider" ascii wide
+		$gen4 = "ComputeHash" ascii wide
 
 		$hashing1 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{32}"\)/ ascii wide
 		$hashing2 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{40}"\)/ ascii wide

--- a/yara/gen_webshells.yar
+++ b/yara/gen_webshells.yar
@@ -6074,24 +6074,3 @@ rule webshell_in_image
 		)
 		) ) )
 }
-
-rule webshell_csharp_hash_regex {
-	meta:
-		description = "C# webshell using specific hash check for the password."
-		license = "Detection Rule License 1.1 https://github.com/Neo23x0/signature-base/blob/master/LICENSE"
-		author = "Nils Kuhnert"
-		hash = "29c187ad46d3059dc25d5f0958e0e8789fb2a51b9daaf90ea27f001b1a9a603c"
-		date = "2022-10-27"
-		score = 55
-	strings:
-		$gen1 = "void Page_Load" ascii wide
-		$gen2 = "FromBase64String" ascii wide
-		$gen3 = "CryptoServiceProvider" ascii wide
-		$gen4 = "ComputeHash" ascii wide
-
-		$hashing1 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{32}"\)/ ascii wide
-		$hashing2 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{40}"\)/ ascii wide
-		$hashing3 = /BitConverter\.ToString\([a-zA-Z0-9]{1,50}\)\.Replace\("-", ""\) == "[A-Fa-f0-9]{64}"\)/ ascii wide
-	condition:
-		all of ($gen*) and 1 of ($hashing*)
-}


### PR DESCRIPTION
Added another Yara rule for detecting C#/ASPX webshells which compair a password param to a hardcoded hash. I've no corpus for checking against legitimate ASPX files, so maybe this needs a bit of testing before merging it.