### PR TITLE
Create gen_metasploit_payloads.yar

### DIFF
--- a/yara/gen_metasploit_payloads.yar
+++ b/yara/gen_metasploit_payloads.yar
@@ -335,6 +335,7 @@ rule HKTL_Meterpreter_inMemory {
       $xs2 = "ReflectiveLoader" ascii fullword
 
       $fp2 = "Sentinel Labs" ascii wide
+      $fp1 = "fortiESNAC" ascii wide
    condition: 
       1 of ($xx*) or 2 of ($x*) 
       and not 1 of ($fp*)


### PR DESCRIPTION
This rule HKTL_Meterpreter_inMemory  will create FP on fortiESNAC.exe - a part of FortiClient