### PR TITLE
Suggestion: remove due to regular FPs

### DIFF
--- a/iocs/keywords.txt
+++ b/iocs/keywords.txt
@@ -15,10 +15,6 @@ privilege::debug
 sekurlsa::LogonPasswords
 sekurlsa::logonpasswords
 
-# Metasploit
-meterpreter
-METERPRETER
-
 # Metasploit PsExec
 %COMSPEC% /C start %COMSPEC% /C \\WINDOWS\\Temp
 


### PR DESCRIPTION
The keyword IOC is checked in many locations and the FP quote is rather high. The IOC is also not available in that form in other locations. Therefore the suggestion to remove it from the signature-base IOCs as well.

If the suggestion is not accepted, you can just close the PR.