### PR TITLE
Add gen_vcruntime140_dll_sideloading.yar

### DIFF
--- a/yara/gen_vcruntime140_dll_sideloading.yar
+++ b/yara/gen_vcruntime140_dll_sideloading.yar
@@ -1,6 +1,6 @@
 rule SUSP_VCRuntime_Sideloading_Indicators_Aug23 {
    meta:
-      description = "Detects indicators of .NET based malware sideloading as VCRUNTIME140"
+      description = "Detects indicators of .NET based malware sideloading as VCRUNTIME140 with .NET DLL imports"
       author = "Jonathan Peters"
       date = "2023-08-30"
       hash = "b4bc73dfe9a781e2fee4978127cb9257bc2ffd67fc2df00375acf329d191ffd6"

--- a/yara/gen_vcruntime140_dll_sideloading.yar
+++ b/yara/gen_vcruntime140_dll_sideloading.yar
@@ -1,0 +1,27 @@
+rule SUSP_VCRuntime_Sideloading_Indicators_Aug23 {
+   meta:
+      description = "Detects indicators of .NET based malware sideloading as VCRUNTIME140"
+      author = "Jonathan Peters"
+      date = "2023-08-30"
+      hash = "b4bc73dfe9a781e2fee4978127cb9257bc2ffd67fc2df00375acf329d191ffd6"
+      score = 75
+   condition:
+      (filename == "VCRUNTIME140.dll" or filename == "vcruntime140.dll")
+      and pe.imports("mscoree.dll", "_CorDllMain")
+}
+
+rule SUSP_VCRuntime_Sideloading_Indicators_1_Aug23 {
+   meta:
+      description = "Detects indicators of .NET based malware sideloading as VCRUNTIME140"
+      author = "Jonathan Peters"
+      date = "2023-08-30"
+      hash = "b4bc73dfe9a781e2fee4978127cb9257bc2ffd67fc2df00375acf329d191ffd6"
+      score = 75
+   strings:
+      $x = "Wine builtin DLL" ascii
+   condition:
+      (filename == "VCRUNTIME140.dll" or filename == "vcruntime140.dll")
+      and ( pe.number_of_signatures == 0
+      or not pe.signatures[0].issuer contain "Microsoft Corporation" )
+      and not $x
+}

--- a/yara/gen_vcruntime140_dll_sideloading.yar
+++ b/yara/gen_vcruntime140_dll_sideloading.yar
@@ -12,7 +12,7 @@ rule SUSP_VCRuntime_Sideloading_Indicators_Aug23 {
 
 rule SUSP_VCRuntime_Sideloading_Indicators_1_Aug23 {
    meta:
-      description = "Detects indicators of .NET based malware sideloading as VCRUNTIME140"
+      description = "Detects indicators of .NET based malware sideloading as an unsigned VCRUNTIME140"
       author = "Jonathan Peters"
       date = "2023-08-30"
       hash = "b4bc73dfe9a781e2fee4978127cb9257bc2ffd67fc2df00375acf329d191ffd6"


### PR DESCRIPTION
Rules covering DLL sideloading of VCRUNTIME140.dll used by malware like JanelaRAT