### PR TITLE
Create MacOS_RustDoor_Malware.yar

### DIFF
--- a/yara/MacOS_RustDoor_Malware.yar
+++ b/yara/MacOS_RustDoor_Malware.yar
@@ -1,0 +1,41 @@
+rule MacOS_RustDoor_Malware {
+    meta:
+        description = "Detects Rust-based backdoor malware targeting macOS systems"
+        author = "Dan Birdsall"
+        reference = "Based on provided information"
+    strings:
+        $rust_commands1 = "ps"
+        $rust_commands2 = "shell"
+        $rust_commands3 = "cd"
+        $rust_commands4 = "mkdir"
+        $rust_commands5 = "rm"
+        $rust_commands6 = "rmdir"
+        $rust_commands7 = "sleep"
+        $rust_commands8 = "upload"
+        $rust_commands9 = "botkill"
+        $rust_commands10 = "dialog"
+        $rust_commands11 = "taskkill"
+        $rust_commands12 = "download"
+
+        $mac_info1 = "machdep.cpu.vendor"
+        $mac_info2 = "machdep.cpu.brand_string"
+        $mac_info3 = "kern.osproductversion"
+        $mac_info4 = "hw.cpufrequency"
+
+        $c2_endpoint1 = "/gateway/register"
+        $c2_endpoint2 = "/gateway/report"
+        $c2_endpoint3 = "/gateway/task"
+        $c2_endpoint4 = "/tasks/upload_file"
+
+        $persistence_method1 = "lock_in_cron"
+        $persistence_method2 = "lock_in_launch"
+        $persistence_method3 = "lock_in_dock"
+        $persistence_method4 = "lock_in_rc"
+    condition:
+        2 of (
+            $rust_commands* or
+            $mac_info* or
+            $c2_endpoint* or
+            $persistence_method*
+        )
+}

--- a/yara/MacOS_RustDoor_Malware.yar
+++ b/yara/MacOS_RustDoor_Malware.yar
@@ -5,38 +5,23 @@ rule MacOS_RustDoor_Malware {
         date = "2024-02-18"
         reference = "https://www.bitdefender.co.uk/blog/labs/new-macos-backdoor-written-in-rust-shows-possible-link-with-windows-ransomware-group/"
     strings:
-        $rust_commands1 = "ps"
-        $rust_commands2 = "shell"
-        $rust_commands3 = "cd"
-        $rust_commands4 = "mkdir"
-        $rust_commands5 = "rm"
-        $rust_commands6 = "rmdir"
-        $rust_commands7 = "sleep"
-        $rust_commands8 = "upload"
-        $rust_commands9 = "botkill"
-        $rust_commands10 = "dialog"
-        $rust_commands11 = "taskkill"
-        $rust_commands12 = "download"
+        $path_notesdb = "Library/Group Containers/group.com.apple.notes/NoteStore.sqlite" ascii
 
-        $mac_info1 = "machdep.cpu.vendor"
-        $mac_info2 = "machdep.cpu.brand_string"
-        $mac_info3 = "kern.osproductversion"
-        $mac_info4 = "hw.cpufrequency"
+        $exfil_ext = /\.(txt|rtf|doc|xls|xlsx|png|pdf|pem|asc|ppk|rdp|zip|sql|ovpn|kdbx|conf|key|json)$/ ascii
 
-        $c2_endpoint1 = "/gateway/register"
-        $c2_endpoint2 = "/gateway/report"
-        $c2_endpoint3 = "/gateway/task"
-        $c2_endpoint4 = "/tasks/upload_file"
+        $exfil_zip = "_home.zip" ascii
 
-        $persistence_method1 = "lock_in_cron"
-        $persistence_method2 = "lock_in_launch"
-        $persistence_method3 = "lock_in_dock"
-        $persistence_method4 = "lock_in_rc"
+        // Persistence mechanism indicators
+        $persistence_cron = "lock_in_cron" ascii
+        $persistence_launch = "lock_in_launch" ascii
+        $persistence_dock = "lock_in_dock" ascii
+        $persistence_rc = "lock_in_rc" ascii
+
+        // Potential Rust command/function call indicators for suspicious activity
+        $rust_command_1 = "exec::command" ascii
+        $rust_command_2 = "std::process::Command" ascii
+        
+
     condition:
-        2 of (
-            $rust_commands* or
-            $mac_info* or
-            $c2_endpoint* or
-            $persistence_method*
-        )
+        1 of ($persistence*) and (2 of ($exfil_ext, $path_notesdb, $exfil_zip) or 1 of ($rust_command_*))
 }

--- a/yara/MacOS_RustDoor_Malware.yar
+++ b/yara/MacOS_RustDoor_Malware.yar
@@ -2,7 +2,8 @@ rule MacOS_RustDoor_Malware {
     meta:
         description = "Detects Rust-based backdoor malware targeting macOS systems"
         author = "Dan Birdsall"
-        reference = "Based on provided information"
+        date = "2024-02-18"
+        reference = "https://www.bitdefender.co.uk/blog/labs/new-macos-backdoor-written-in-rust-shows-possible-link-with-windows-ransomware-group/"
     strings:
         $rust_commands1 = "ps"
         $rust_commands2 = "shell"


### PR DESCRIPTION
Based upon https://www.bitdefender.co.uk/blog/labs/new-macos-backdoor-written-in-rust-shows-possible-link-with-windows-ransomware-group/