### PR TITLE
Update vuln_paloalto_cve_2024_3400_apr24.yar

### DIFF
--- a/yara/vuln_paloalto_cve_2024_3400_apr24.yar
+++ b/yara/vuln_paloalto_cve_2024_3400_apr24.yar
@@ -83,6 +83,7 @@ rule SUSP_LNX_Base64_Exec_Apr24 : SCRIPT {
       description = "Detects suspicious base64 encoded shell commands (as seen in Palo Alto CVE-2024-3400 exploitation)"
       author = "Christian Burkard"
       date = "2024-04-18"
+      modified = "2025-01-17"
       reference = "Internal Research"
       score = 75
       id = "2da3d050-86b0-5903-97eb-c5f39ce4f3a3"
@@ -93,7 +94,6 @@ rule SUSP_LNX_Base64_Exec_Apr24 : SCRIPT {
       $s4 = "/tmp/" base64
       
       $mirai = "country="
-      
    condition:
       any of them and not $mirai
 }

--- a/yara/vuln_paloalto_cve_2024_3400_apr24.yar
+++ b/yara/vuln_paloalto_cve_2024_3400_apr24.yar
@@ -91,6 +91,9 @@ rule SUSP_LNX_Base64_Exec_Apr24 : SCRIPT {
       $s2 = "wget http://" base64
       $s3 = ";chmod 777 " base64
       $s4 = "/tmp/" base64
+      
+      $mirai = "country="
+      
    condition:
-      all of them
+      any of them and not $mirai
 }


### PR DESCRIPTION
Just saw a case where curl / wget commands missed due to different order and this ruleset failed. 
Assumption is you added all of them command due to account for FP on mirai entries so modified this rule to take that into account and use "any of them" instead.