### PR TITLE
Update RegEx Patterns for YARA-X Compatibility

### DIFF
--- a/yara/apt_sandworm_centreon.yar
+++ b/yara/apt_sandworm_centreon.yar
@@ -112,7 +112,7 @@ rule APT_MAL_Sandworm_Exaramel_Configuration_File_Plaintext {
       score = 80
       id = "6f0d834b-e6c8-59e6-bf9a-b4fd9c0b2297"
    strings:
-      $ = /{"Hosts":\[".{10,512}"\],"Proxy":".{0,512}","Version":".{1,32}","Guid":"/
+      $ = /\{"Hosts":\[".{10,512}"\],"Proxy":".{0,512}","Version":".{1,32}","Guid":"/
    condition:
       all of them
 }

--- a/yara/gen_fireeye_redteam_tools.yar
+++ b/yara/gen_fireeye_redteam_tools.yar
@@ -1886,7 +1886,7 @@ rule APT_Loader_Win_PGF_1
         id = "fcbefa45-8dcd-57a3-a2ac-f4613152716f"
     strings:
         $pdb1 = /RSDS[\x00-\xFF]{20}c:\\source\\dllconfig-master\\dllsource[\x00-\xFF]{0,500}\.pdb\x00/ nocase
-        $pdb2 = /RSDS[\x00-\xFF]{20}C:\\Users\\Developer\\Source[\x00-\xFF]{0,500}\Release\\DllSource\.pdb\x00/ nocase
+        $pdb2 = /RSDS[\x00-\xFF]{20}C:\\Users\\Developer\\Source[\x00-\xFF]{0,500}\\Release\\DllSource\.pdb\x00/ nocase
         $pdb3 = /RSDS[\x00-\xFF]{20}q:\\objchk_win7_amd64\\amd64\\init\.pdb\x00/ nocase
     condition:
         (uint16(0) == 0x5A4D) and (uint32(uint32(0x3C)) == 0x00004550) and filesize < 15MB and any of them

--- a/yara/gen_webshells.yar
+++ b/yara/gen_webshells.yar
@@ -1987,7 +1987,7 @@ rule WEBSHELL_PHP_Dynamic
         $dynamic6 = /\$[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\[\]'"]{0,20}\s{0,20}\(@/ wide ascii
         $dynamic7 = /\$[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff\[\]'"]{0,20}\s{0,20}\(base64_decode/ wide ascii
         // ${'_'.$_}["_"](${'_'.$_}["__"]
-        $dynamic8 = /\${[^}]{1,20}}(\[[^\]]{1,20}\])?\(\${/ wide ascii
+        $dynamic8 = /\$\{[^}]{1,20}}(\[[^\]]{1,20}\])?\(\$\{/ wide ascii
 
         $fp1 = { 3C 3F 70 68 70 0A 0A 24 61 28 24 62 20 3D 20 33 2C 20 24 63 29 3B } /* <?php\x0a\x0a$a($b = 3, $c); */
         $fp2 = { 3C 3F 70 68 70 0A 0A 24 61 28 24 62 20 3D 20 33 2C 20 2E 2E 2E 20 24 63 29 3B } /* <?php\x0a\x0a$a($b = 3, ... $c); */
@@ -2442,7 +2442,7 @@ rule WEBSHELL_PHP_Generic_Backticks
 
         id = "b2f1d8d0-8668-5641-8ce9-c8dd71f51f58"
     strings:
-        $backtick = /`\s*{?\$(_POST\[|_GET\[|_REQUEST\[|_SERVER\['HTTP_)/ wide ascii
+        $backtick = /`\s*\{?\$(_POST\[|_GET\[|_REQUEST\[|_SERVER\['HTTP_)/ wide ascii
 
         //strings from private rule capa_php_old_safe
         $php_short = "<?" wide ascii
@@ -6158,13 +6158,13 @@ rule WEBSHELL_JSP_Generic_Encoded_Shell
 
         id = "359949d7-1793-5e13-9fdc-fe995ae12117"
     strings:
-        $sj0 = /{ ?47, 98, 105, 110, 47, 98, 97, 115, 104/ wide ascii
-        $sj1 = /{ ?99, 109, 100}/ wide ascii
-        $sj2 = /{ ?99, 109, 100, 46, 101, 120, 101/ wide ascii
-        $sj3 = /{ ?47, 98, 105, 110, 47, 98, 97/ wide ascii
-        $sj4 = /{ ?106, 97, 118, 97, 46, 108, 97, 110/ wide ascii
-        $sj5 = /{ ?101, 120, 101, 99 }/ wide ascii
-        $sj6 = /{ ?103, 101, 116, 82, 117, 110/ wide ascii
+        $sj0 = /\{ ?47, 98, 105, 110, 47, 98, 97, 115, 104/ wide ascii
+        $sj1 = /\{ ?99, 109, 100}/ wide ascii
+        $sj2 = /\{ ?99, 109, 100, 46, 101, 120, 101/ wide ascii
+        $sj3 = /\{ ?47, 98, 105, 110, 47, 98, 97/ wide ascii
+        $sj4 = /\{ ?106, 97, 118, 97, 46, 108, 97, 110/ wide ascii
+        $sj5 = /\{ ?101, 120, 101, 99 }/ wide ascii
+        $sj6 = /\{ ?103, 101, 116, 82, 117, 110/ wide ascii
 
     condition:
         filesize <300KB and any of ($sj*)


### PR DESCRIPTION
This PR updates regular expression strings in 3 YAR files for YARA-X compatibility. Fixing these rules also makes the YARAForge Full package compatible with YARA-X with only warnings during compilation.