### PR TITLE
YARA signatures for nfs-security-tooling by HvS Consulting

### DIFF
--- a/yara/hktl_HvS_nfs_security_tooling.yar
+++ b/yara/hktl_HvS_nfs_security_tooling.yar
@@ -1,0 +1,49 @@
+rule fuse_nfs {
+   meta:
+      description = "Detects the nfs-security-tooling fuse_nfs by HvS Consulting"
+      license = "https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "Moritz Oettle"
+      date = "2024-10-22"
+      reference1 = "https://github.com/hvs-consulting/nfs-security-tooling"
+
+   strings:
+      $s1 = "NFS3ConnectionFactory" fullword ascii
+      $s2 = "fuse_to_nfs_timestamp" fullword ascii
+      $s3 = "--manual-fh" fullword ascii
+      $s4 = "--fake-uid-allow-root" fullword ascii
+      $s5 = "nfs.rpc.credential" fullword ascii
+      $s6 = "nfs.readlink" fullword ascii
+      $s7 = "pyfuse3.EntryAttributes" fullword ascii
+      $s8 = "Make nested exports on NetApp servers work" fullword ascii
+      $s9 = "add_mutually_exclusive_group" fullword ascii
+
+   condition:
+      4 of them
+}
+
+rule nfs_analyze {
+   meta:
+      description = "Detects the nfs-security-tooling nfy_analyze by HvS Consulting"
+      license = "https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "Marc Stroebel"
+      date = "2024-10-22"
+      reference1 = "https://github.com/hvs-consulting/nfs-security-tooling"
+      
+   strings:
+      $s1 = "no_root_squash_exports" fullword ascii
+      $s2 = "nfs lock manager" fullword ascii
+      $s3 = "netapp partner" fullword ascii
+      $s4 = "xdrdef.mnt3_type" fullword ascii
+      $s5 = "BTRFS subvolumes" fullword ascii
+      $s6 = "Unsupported fsid" fullword ascii
+      $s7 = "nfs3_read_etc_shadow" fullword ascii
+      $s8 = "nfs3_check_no_root_squash" fullword ascii
+      $s9 = "krb5i" fullword ascii
+      $s10 = "nfs4_overview" fullword ascii
+      $s11 = "--btrfs-subvolumes" fullword ascii
+      $s12 = "when escaping a BTRFS export" fullword ascii
+      $s13 = "No NFS server detected" fullword ascii
+
+   condition:
+      6 of them
+}

--- a/yara/hktl_HvS_nfs_security_tooling.yar
+++ b/yara/hktl_HvS_nfs_security_tooling.yar
@@ -1,10 +1,11 @@
-rule fuse_nfs {
+rule HKTL_NFS_Fuse_NFS {
    meta:
       description = "Detects the nfs-security-tooling fuse_nfs by HvS Consulting"
       license = "https://creativecommons.org/licenses/by-nc/4.0/"
       author = "Moritz Oettle"
       date = "2024-10-22"
-      reference1 = "https://github.com/hvs-consulting/nfs-security-tooling"
+      score = 75
+      reference = "https://github.com/hvs-consulting/nfs-security-tooling"
 
    strings:
       $s1 = "NFS3ConnectionFactory" fullword ascii
@@ -21,13 +22,14 @@ rule fuse_nfs {
       4 of them
 }
 
-rule nfs_analyze {
+rule HKTL_NFS_NFS_Analyze {
    meta:
       description = "Detects the nfs-security-tooling nfy_analyze by HvS Consulting"
       license = "https://creativecommons.org/licenses/by-nc/4.0/"
       author = "Marc Stroebel"
       date = "2024-10-22"
-      reference1 = "https://github.com/hvs-consulting/nfs-security-tooling"
+      score = 75
+      reference = "https://github.com/hvs-consulting/nfs-security-tooling"
       
    strings:
       $s1 = "no_root_squash_exports" fullword ascii


### PR DESCRIPTION
Our HvS Pentesting colleagues have identified attacks against NFS and developed pentesting tools specifically for NFS. More information can be found here: https://www.hvs-consulting.de/en/nfs-security-identifying-and-exploiting-misconfigurations/

The rules fuse_nfs and nts_analyze are written to detect the presence of NFS pentesting tools.