### PR TITLE
Add YARA Rules for Akira & Megazord Ransowmare

### DIFF
--- a/yara/mal_win_akira_apr25.yar
+++ b/yara/mal_win_akira_apr25.yar
@@ -1,0 +1,28 @@
+rule MAL_WIN_Akira_Apr25 {
+    meta:
+        description = "This Yara rule from ISH Tecnologia's Heimdall Security Research Team detects key components of Akira Ransomware"
+        author = "0x0d4y-Ícaro César"
+        date = "2025-04-11"
+        score = 90
+        reference = "https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf"
+        hash = "205589629EAD5D3C1D9E914B49C08589"
+        uuid = "76722cb6-70be-465f-9ef1-afd78f694289"
+        license = "Detection Rule License 1.1 https://github.com/Neo23x0/signature-base/blob/master/LICENSE"
+        rule_matching_tlp = "TLP:WHITE"
+        rule_sharing_tlp = "TLP:WHITE"
+        malpedia_family = "win.akira"
+
+    strings:
+        $code_custom_algorithm = { 44 8B CF 90 42 0F B6 4C 0D ?? 83 E9 4E 44 8D 04 89 45 03 C0 B8 09 04 02 81 41 F7 E8 41 03 D0 C1 FA 06 8B C2 C1 E8 1F 03 D0 6B C2 7F 44 2B C0 41 83 C0 7F B8 09 04 02 81 41 F7 E8 41 03 D0 C1 FA 06 8B C2 C1 E8 1F 03 D0 6B C2 7F 44 2B C0 46 88 44 0D ?? 49 FF C1 }
+        $code_aes_key_expansion = { 41 8D 41 FF 33 D2 8B 0C ?? 41 8B C1 41 F7 F2 85 D2 75 ?? 44 8B C1 0F B6 C1 0F B6 0C ?? 41 8B C0 48 C1 E8 ?? C1 E1 ?? 0F B6 04 ?? 0B C8 41 8B C0 48 C1 E8 ?? C1 E1 ?? 0F B6 D0 49 C1 E8 ?? 0F B6 04 ?? 0B C8 41 0F B6 C0 C1 E1 ?? 0F B6 14 ?? 0F B6 45 00 0B CA 33 C8 48 FF C5 }
+        $akira_str_I = "akira" ascii
+        $akira_str_II = "onion" ascii
+        $akira_str_III = "powershell" ascii
+        $akira_str_IV = "akira_readme.txt" ascii
+
+
+    condition:
+        uint16(0) == 0x5a4d and
+        all of ($code_*) and
+        all of ($akira_str_*)
+}

--- a/yara/mal_win_akira_apr25.yar
+++ b/yara/mal_win_akira_apr25.yar
@@ -1,7 +1,7 @@
 rule MAL_WIN_Akira_Apr25 {
     meta:
         description = "This Yara rule from ISH Tecnologia's Heimdall Security Research Team detects key components of Akira Ransomware"
-        author = "0x0d4y-Ícaro César"
+        author = "0x0d4y-Icaro Cesar"
         date = "2025-04-11"
         score = 90
         reference = "https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf"

--- a/yara/mal_win_megazord_apr25.yar
+++ b/yara/mal_win_megazord_apr25.yar
@@ -1,7 +1,7 @@
 rule MAL_WIN_Megazord_Apr25 {
     meta:
         description = "This Yara rule from ISH Tecnologia's Heimdall Security Research Team, detects the main components of the Megazord Ransomware"
-        author = "0x0d4y-Ícaro César"
+        author = "0x0d4y-Icaro Cesar"
         date = "2025-04-11"
         score = 80
         reference = "https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf"

--- a/yara/mal_win_megazord_apr25.yar
+++ b/yara/mal_win_megazord_apr25.yar
@@ -1,0 +1,30 @@
+rule MAL_WIN_Megazord_Apr25 {
+    meta:
+        description = "This Yara rule from ISH Tecnologia's Heimdall Security Research Team, detects the main components of the Megazord Ransomware"
+        author = "0x0d4y-Ícaro César"
+        date = "2025-04-11"
+        score = 80
+        reference = "https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf"
+        hash = "FD380DB23531BB7BB610A7B32FC2A6D5"
+        uuid = "6225a690-8f54-4a50-a19a-8f7523537228"
+        license = "Detection Rule License 1.1 https://github.com/Neo23x0/signature-base/blob/master/LICENSE"
+        rule_matching_tlp = "TLP:WHITE"
+        rule_sharing_tlp = "TLP:WHITE"
+        malpedia_family = "win.akira"
+
+    strings:
+        $code_custom_algorithm = { 89 c1 45 31 e6 31 e8 44 31 f0 35 ?? ?? ?? ?? c1 c0 0b 44 31 ff 44 31 ef 31 c7 81 f7 ?? ?? ?? ?? c1 c7 0b 44 31 e3 31 cb 31 fb 81 f3 ?? ?? ?? ?? c1 c3 0b 89 da 31 c2 89 84 24 ?? ?? ?? ?? 44 31 ed 31 d5 89 94 24 ?? ?? ?? ?? 81 f5 ?? ?? ?? ?? c1 c5 0b 41 89 e8 41 31 f8 89 bc 24 ?? ?? ?? ?? 41 31 cf 45 31 c7 44 89 84 24 ?? ?? ?? ?? 41 81 f7 ?? ?? ?? ?? 41 c1 c7 0b 41 31 d4 45 31 fc 41 81 f4 ?? ?? ?? ?? 41 c1 c4 0b 45 31 c5 45 31 e5 41 81 f5 ?? ?? ?? ?? 41 c1 c5 0b 89 9c 24 ?? ?? ?? ?? 31 d9 44 31 f9 44 31 e9 81 f1 ?? ?? ?? ?? c1 c1 0b 41 89 c8 45 31 e0 44 89 a4 24 ?? ?? ?? ?? 89 ac 24 ?? ?? ?? ?? 31 e8 44 31 c0 35 ?? ?? ?? ?? c1 c0 0b 44 89 fa 44 89 bc 24 ?? ?? ?? ?? 31 fa 44 31 ea 31 c2 41 89 c1 81 f2 ?? ?? ?? ?? c1 c2 0b 41 31 d8 41 31 d0 41 81 f0 ?? ?? ?? ?? 41 c1 c0 0b 44 89 e8 44 89 ac 24 ?? ?? ?? ?? 31 e8 44 31 c8 44 31 c0 45 89 c3 35 }
+        $megazord_str_I = "powerranges" ascii
+        $megazord_str_II = "onion" ascii
+        $megazord_str_III = "powershell" ascii
+        $megazord_str_IV = "taskkill" ascii
+        $megazord_str_V = "mal_public_key_bytes" ascii
+        $megazord_str_VI = "runneradmin" ascii
+        $megazord_str_VII = "//rustc" ascii
+
+
+    condition:
+        uint16(0) == 0x5a4d and
+        $code_custom_algorithm and
+        5 of ($megazord_str_*)
+}


### PR DESCRIPTION
# Yara Rule for the Akira and Megazord Ransomware

Contributing to the signature base, with the Yara rules for the Akira ransomware and its variant the Megazord ransomware, taking as reference the [public research](https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf) of the Heimdall Security Research team, in which I developed all the technical analysis and the Yara signatures present in this commit.