### PR TITLE
Addition of RALord, Akira and Megazord Ransomware IOCs & Yara Rule Update

### DIFF
--- a/iocs/hash-iocs.txt
+++ b/iocs/hash-iocs.txt
@@ -11458,3 +11458,12 @@ aa9f5ed1eede9aac6d07b0ba13b73185838b159006fa83ed45657d7f333a0efe;ScreenConnect E
 cf265a3a3dd068d0aa0c70248cd6325d;perfctl IOCs https://www.aquasec.com/blog/perfctl-a-stealthy-malware-targeting-millions-of-linux-servers/
 da006a0b9b51d56fa3f9690cf204b99f;perfctl IOCs https://www.aquasec.com/blog/perfctl-a-stealthy-malware-targeting-millions-of-linux-servers/
 ba120e9c7f8896d9148ad37f02b0e3cb;perfctl IOCs https://www.aquasec.com/blog/perfctl-a-stealthy-malware-targeting-millions-of-linux-servers/
+
+3298d203c2acb68c474e5fdad8379181890b4403d6491c523c13730129be3f75; Akira IOCs https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf
+ae455890e2123a9d011e47065828b0a03c08fd66570fab9d0340d2f5d5eb40c3; Akira IOCs https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf
+0ee1d284ed663073872012c7bde7fac5ca1121403f1a5d2d5411317df282796c; Akira IOCs https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf
+dfe6fddc67bdc93b9947430b966da2877fda094edf3e21e6f0ba98a84bc53198; Megazord IOCs https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf
+131da83b521f610819141d5c740313ce46578374abb22ef504a7593955a65f07; Megazord IOCs https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf
+9f393516edf6b8e011df6ee991758480c5b99a0efbfd68347786061f0e04426c; Megazord IOCs https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf
+
+456b9adaabae9f3dce2207aa71410987f0a571cd8c11f2e7b41468501a863606; RALord IOCs https://ish.com.br/wp-content/uploads/2025/04/RALord-Novo-grupo-de-Ransomware-as-a-Service-1.pdf

--- a/yara/mal_win_megazord_apr25.yar
+++ b/yara/mal_win_megazord_apr25.yar
@@ -2,7 +2,7 @@ rule MAL_WIN_Megazord_Apr25 {
     meta:
         description = "This Yara rule from ISH Tecnologia's Heimdall Security Research Team, detects the main components of the Megazord Ransomware"
         author = "0x0d4y-Icaro Cesar"
-        date = "2025-04-11"
+        date = "2025-04-16"
         score = 80
         reference = "https://ish.com.br/wp-content/uploads/2025/04/A-Anatomia-do-Ransomware-Akira-e-sua-expansao-multiplataforma.pdf"
         hash = "FD380DB23531BB7BB610A7B32FC2A6D5"
@@ -13,11 +13,10 @@ rule MAL_WIN_Megazord_Apr25 {
         malpedia_family = "win.akira"
 
     strings:
-        $code_custom_algorithm = { 89 c1 45 31 e6 31 e8 44 31 f0 35 ?? ?? ?? ?? c1 c0 0b 44 31 ff 44 31 ef 31 c7 81 f7 ?? ?? ?? ?? c1 c7 0b 44 31 e3 31 cb 31 fb 81 f3 ?? ?? ?? ?? c1 c3 0b 89 da 31 c2 89 84 24 ?? ?? ?? ?? 44 31 ed 31 d5 89 94 24 ?? ?? ?? ?? 81 f5 ?? ?? ?? ?? c1 c5 0b 41 89 e8 41 31 f8 89 bc 24 ?? ?? ?? ?? 41 31 cf 45 31 c7 44 89 84 24 ?? ?? ?? ?? 41 81 f7 ?? ?? ?? ?? 41 c1 c7 0b 41 31 d4 45 31 fc 41 81 f4 ?? ?? ?? ?? 41 c1 c4 0b 45 31 c5 45 31 e5 41 81 f5 ?? ?? ?? ?? 41 c1 c5 0b 89 9c 24 ?? ?? ?? ?? 31 d9 44 31 f9 44 31 e9 81 f1 ?? ?? ?? ?? c1 c1 0b 41 89 c8 45 31 e0 44 89 a4 24 ?? ?? ?? ?? 89 ac 24 ?? ?? ?? ?? 31 e8 44 31 c0 35 ?? ?? ?? ?? c1 c0 0b 44 89 fa 44 89 bc 24 ?? ?? ?? ?? 31 fa 44 31 ea 31 c2 41 89 c1 81 f2 ?? ?? ?? ?? c1 c2 0b 41 31 d8 41 31 d0 41 81 f0 ?? ?? ?? ?? 41 c1 c0 0b 44 89 e8 44 89 ac 24 ?? ?? ?? ?? 31 e8 44 31 c8 44 31 c0 45 89 c3 35 }
         $megazord_str_I = "powerranges" ascii
         $megazord_str_II = "onion" ascii
         $megazord_str_III = "powershell" ascii
-        $megazord_str_IV = "taskkill" ascii
+        $megazord_str_IV = "megazord" ascii
         $megazord_str_V = "mal_public_key_bytes" ascii
         $megazord_str_VI = "runneradmin" ascii
         $megazord_str_VII = "//rustc" ascii
@@ -25,6 +24,5 @@ rule MAL_WIN_Megazord_Apr25 {
 
     condition:
         uint16(0) == 0x5a4d and
-        $code_custom_algorithm and
-        5 of ($megazord_str_*)
+        6 of ($megazord_str_*)
 }


### PR DESCRIPTION
Sorry for this confusing PR! I added the hashes and created a PR for it, and I was going to create another PR for the update of the MAL_WIN_Megazord_Apr25 rule, but I didn't pay attention and the commit went to the same PR.

# Adding Hashes SHA256

Added SHA256 Hashes of some RALord, Akira and Megazord ransomware samples, on commit [240d497](https://github.com/Neo23x0/signature-base/pull/346/commits/240d4972fc413f39347f68809d301c6b5323db2c).

# Updating the Yara Rule MAL_WIN_Megazord_Apr25

Performing some extra validation, I realized that the code pattern condition was not matching the extra samples I collected. I realized that in this case the best strategy would be to focus on the set of strings that make up the Megazord. Would this be a good strategy?

The commit for this update is in [7fe549e](https://github.com/Neo23x0/signature-base/pull/346/commits/7fe549e9240a6fee83289c391a29d808a2e9a9d2).