### PR TITLE
Add YARA Rule for China-Nexus APT Veletrix Loader

### DIFF
--- a/yara/apt_veletrix_loader_072025.yar
+++ b/yara/apt_veletrix_loader_072025.yar
@@ -1,0 +1,21 @@
+rule apt_veletrix_loader_072025 {
+  meta:
+      author = "0x0d4y"
+      description = "This rule detects intrinsic patterns of Veletrix Loader."
+      date = "2025-07-07"
+      score = 100
+      reference = "https://0x0d4y.blog/telecommunications-supply-chain-china-nexus-threat-technical-analysis-of-veletrix-loaders-strategic-infrastructure-positioning/"
+      yarahub_reference_md5 = "81f76f83d4c571fe95772f21aff4d0b9"
+      yarahub_uuid = "b8554d55-8563-4a5e-9e12-294cdbb9b593"
+      yarahub_license = "CC BY 4.0"
+      yarahub_rule_matching_tlp = "TLP:WHITE"
+      yarahub_rule_sharing_tlp = "TLP:WHITE"
+      malware_family = "win.veletrix"
+
+    strings:
+    $decryption_shellcode_algorithm = { 8B 57 08 48 8B C8 41 FF D5 E8 ?? ?? ?? ?? 48 8B 4F 08 33 D2 48 FF C1 48 98 48 F7 F1 89 57 04 66 0F 1F 84 00 00 00 00 00 48 63 C3 F0 80 34 30 ?? FF C3 81 FB 73 05 00 00 72 ?? 8B 47 04 4C 8B C6 48 03 47 10 BA 74 05 00 00 4C 2B C0 [0-16] 41 0F B6 0C 00 88 08 }
+
+    condition:
+        uint16(0) == 0x5a4d and
+        $decryption_shellcode_algorithm
+}

--- a/yara/apt_veletrix_shellcode_072025.yar
+++ b/yara/apt_veletrix_shellcode_072025.yar
@@ -1,0 +1,22 @@
+rule apt_veletrix_shellcode_072025 {
+    meta:
+        author = "0x0d4y"
+        description = "This rule detects intrinsic patterns of Veletrix Shellcode."
+        date = "2025-07-07"
+        score = 100
+        reference = "https://0x0d4y.blog/telecommunications-supply-chain-china-nexus-threat-technical-analysis-of-veletrix-loaders-strategic-infrastructure-positioning/"
+        yarahub_reference_md5 = "81f76f83d4c571fe95772f21aff4d0b9"
+        yarahub_uuid = "1d4c08bc-0498-43bb-81f3-08477d81233e"
+        yarahub_license = "CC BY 4.0"
+        yarahub_rule_matching_tlp = "TLP:WHITE"
+        yarahub_rule_sharing_tlp = "TLP:WHITE"
+        malware_family = "win.veletrix"
+
+    strings:
+        $decryption_2ndstage_algorithm = { 45 33 C0 85 C0 74 ?? 41 8D 0C 30 45 03 C6 80 34 39 ?? 44 3B C0 72 ?? 03 F0 8B D6 48 03 D7 }
+        $ror13_alg = { 0F BE 01 C1 CA 0D 80 39 61 7C 03 83 C2 E0 03 D0 48 FF C1 49 83 EA 01 75 }
+
+    condition:
+        $decryption_2ndstage_algorithm and
+        $ror13_alg
+}


### PR DESCRIPTION
I have done a research in my personal [blog](https://0x0d4y.blog/telecommunications-supply-chain-china-nexus-threat-technical-analysis-of-veletrix-loaders-strategic-infrastructure-positioning/) about the Veletrix Loader, used in China-Nexus Campaign against Telecommunication China Industry. From these research, I create this YARA rule.