### PR TITLE
Added yara rule for bluehammer exploit executable

### DIFF
--- a/yara/exploit_bluehammer.yar
+++ b/yara/exploit_bluehammer.yar
@@ -1,0 +1,31 @@
+
+rule EXPL_BLueHammer_FunnyApp {
+   meta:
+      description = "Detects the original bluehammer exploit executable hosted on github."
+      author = "Moritz Oettle (HvS-Consulting GmbH)"
+      date = "2026-04-08"
+      hash1 = "93008c42764b74b759678fd376abd90696f74af408600727b6649286d8424270"
+      score = 75
+      id = "b3afcbc4-f001-4f8e-b2ed-4cfd4097d8e6"
+   strings:
+      $s1 = "C:\\Users\\admin\\source\\repos\\FunnyApp\\x64\\Release\\FunnyApp.pdb" fullword ascii
+      $s2 = "Failed to dump LSA secret keys." fullword ascii
+      $s3 = "Failed to import required functions from samlib.dll" fullword ascii
+      $s4 = "Failed to load samlib.dll" fullword ascii
+      $s5 = "OpenProcessToken failed, error : %d" fullword ascii
+      $s6 = "Failed to create event object with error : %d !!!!" fullword ascii
+      $s7 = "Unexpected error while building an RPC binding from string !!!" fullword ascii
+      $s8 = "Failed to connect to windows defender RPC port !!!" fullword ascii
+      $s9 = "Failed to allocate memory to download file !!!" fullword ascii
+      $s10 = "Failed to allocate memory !!!" fullword ascii
+      $s11 = "Waiting for oplock to trigger..." fullword ascii
+      $s12 = "Failed to open restart manager dll for exclusive access, error : %d" fullword ascii
+      $s13 = "Oplock triggered." fullword ascii
+      $s14 = "Failed to load samlib.dll" fullword ascii   
+      $s15 = "$PWNed666!!!WDFAIL" fullword ascii
+      $s16 = "Failed to allocate enough memory to copy leaked file !!!" fullword ascii
+
+   condition:
+      uint16(0) == 0x5a4d and filesize < 5000KB and 4 of ($s*)
+}
+


### PR DESCRIPTION
After the public disclosure of the bluehammer exploit, I wanted to quickly produce a Yara rule for the executable hosted on the bluehammer github repo: https://github.com/Nightmare-Eclipse/BlueHammer