### PR TITLE
Add YARA rule for UniCraft Launcher Spyware (spy_unicraft_launcher.yar)

### DIFF
--- a/yara/spy_unicraft_launcher.yar
+++ b/yara/spy_unicraft_launcher.yar
@@ -1,0 +1,77 @@
+rule Multi_Spyware_UniCraft {
+    meta:
+        description = "Detects UniCraft Launcher spyware behavior. This rule targets unpacked payloads (ASAR/JS) and will not trigger on compressed installers (NSIS/SquashFS/DMG) until they are extracted."
+        author = "koder-cog"
+        version = "1.0"
+        creation_date = "2026-04-20"
+        last_modified = "2026-04-20"
+        
+        // Context & Naming
+        os = "Windows, Linux, MacOS"
+        arch_context = "x86, ARM"
+        threat_name = "Multi.Spyware.UniCraft"
+        severity = "Critical"
+        category = "spyware"
+        scan_context = "File, Memory"
+        tlp = "CLEAR"
+        
+        // Samples & References
+        reference_sample = "2447653155fe0e6fc9b3dfb43fe1abfd20b18b6115ddca77bbc045580650548d"
+        reference_1 = "https://www.virustotal.com/gui/file-analysis/YTBmM2I4ZGQwMmFkMmNmOTNmZWUyYzZiODE0MjM2ZjM6MTc3NjY5NTIzNg=="
+        reference_2 = "https://www.virustotal.com/gui/file/2447653155fe0e6fc9b3dfb43fe1abfd20b18b6115ddca77bbc045580650548d"
+        
+        // Sample Hashes (SHA-256)
+        hash_1 = "a4f665013fb380fc3936c5837351a1b8340359fe6023166b2d9e930193f89007"
+        hash_2 = "2447653155fe0e6fc9b3dfb43fe1abfd20b18b6115ddca77bbc045580650548d"
+        
+    strings:
+        // Identity Indicators
+        $id_1 = "UniCraft Launcher" ascii wide
+        $id_2 = "net.unicraft.launcher" ascii wide
+        $id_3 = ".unicraft" ascii wide
+        $id_path = /\.unicraft[\\\/](config|mods|logs)/ ascii wide
+        
+        // C2 Infrastructure (Subdomain-Agnostic & IP-based)
+        $c2_brand = /[a-zA-Z0-9-]*\.?unicraftmc\.[a-z]{2,6}/ ascii wide
+        $c2_legacy = /(unicraft\.sbs|api\.gogusler\.de|updates\.gogusler\.de)/ ascii wide
+        $c2_ip = "213.146.165.119" ascii wide
+        
+        // C2 Infrastructure (Base64 variants for evasion)
+        $c2_b64_brand = "unicraftmc" base64 base64wide
+        $c2_b64_legacy = "gogusler" base64 base64wide
+        
+        // Actions: Data Theft (HWID & Session)
+        $action_1 = "X-Launcher-HWID" ascii wide
+        $action_2 = "hwid-cache.json" ascii wide
+        $action_3 = "LAUNCHER_ID" ascii wide
+        $action_4 = "Get-WmiObject Win32_ComputerSystemProduct" ascii wide
+        $action_5 = "Get-CimInstance Win32_ComputerSystemProduct" ascii wide
+        $action_6 = "unicraft-session.enc" ascii wide
+        $action_7 = "Win32_ComputerSystemProduct" ascii wide
+
+        // Actions: Data Theft (Base64 variants)
+        $action_b64_1 = "Get-WmiObject Win32_ComputerSystemProduct" base64 base64wide
+        $action_b64_2 = "Get-CimInstance Win32_ComputerSystemProduct" base64 base64wide
+        
+        // Actions: Evasion & Sabotage
+        $evade_1 = "reportSecurityEvent" ascii wide
+        $evade_2 = "acquireInstanceSlot" ascii wide
+        $evade_3 = "cheat_process_detected" ascii wide
+        $evade_4 = "foreign_jar_detected" ascii wide
+        $evade_5 = "tasklist" ascii wide nocase
+        $evade_6 = "icacls" ascii wide nocase
+        $evade_7 = "reg delete" ascii wide nocase
+
+    condition:
+        // Exclude large assets; target main script/resource files
+        filesize < 20MB and
+        
+        // Logic: Identity AND C2 AND (Direct Theft OR 2+ Evasion behaviors)
+        (1 of ($id_*)) and
+        (any of ($c2_*)) and
+        (
+            1 of ($action_*) or 
+            1 of ($action_b64_*) or 
+            2 of ($evade_*) 
+        )
+}


### PR DESCRIPTION
## What this rule detects
This rule is designed to identify the unpacked payloads (ASAR/JS scripts) of the UniCraft Launcher spyware. It focuses on multi-platform threats (Windows, Linux, macOS) and detects the core malicious logic rather than compressed installers (like NSIS, SquashFS, or DMG).

## Why it's important
This specific payload poses a critical risk to users due to the following malicious behaviors:
- It actively attempts to steal Hardware IDs (HWID) using WMI/CIM and extracts session tokens (`unicraft-session.enc`).
- It actively monitors for analysis/cheat processes (`cheat_process_detected`, `tasklist`) and manipulates system permissions/registry (`icacls`, `reg delete`).
- It connects to specific infrastructure (e.g., `api.unicraftmc.com`, `213.146.165.119`) and uses Base64 encoding to obfuscate these endpoints.

## Rule Logic
To minimize false positives, the rule condition requires a combination of:
1. Identity Indicators (UniCraft brand/paths) AND
2. Known C2 Infrastructure AND
3. At least 1 Direct Theft behavior OR at least 2 Evasion/Sabotage behaviors.

## References & Samples
- Recorded Future Report (2.4.3): https://tria.ge/260417-w68nlsfw9j
- Recorded Future Report (2.4.5): https://tria.ge/260418-mhgqjscy5y
- Recorded Future Report (2.4.7): https://tria.ge/260419-n2c25shv5p

- VirusTotal File Analysis (2.2.7): https://www.virustotal.com/gui/file/a4f665013fb380fc3936c5837351a1b8340359fe6023166b2d9e930193f89007
- SHA-256: `a4f665013fb380fc3936c5837351a1b8340359fe6023166b2d9e930193f89007`
- VirusTotal File Analysis (2.4.9): https://www.virustotal.com/gui/file/2447653155fe0e6fc9b3dfb43fe1abfd20b18b6115ddca77bbc045580650548d
- SHA-256: `2447653155fe0e6fc9b3dfb43fe1abfd20b18b6115ddca77bbc045580650548d`

Let me know if any adjustments or formatting changes are needed.