### PR TITLE
Add YARA rules for Spring Boot Actuator egress (CVE-2026-40976 + general)

### DIFF
--- a/yara/expl_spring_boot_actuator_egress_apr26.yar
+++ b/yara/expl_spring_boot_actuator_egress_apr26.yar
@@ -1,0 +1,53 @@
+/*
+   YARA rules for detection of Spring Boot Actuator data egress, motivated by
+   CVE-2026-40976 (Spring Boot 4.0.0-4.0.5 default-security misconfigured when
+   spring-boot-actuator-autoconfigure is on the classpath without
+   spring-boot-health). Both rules are CVE-AGNOSTIC: they fire on any Spring
+   Boot deployment where actuator data is reaching an unintended client,
+   regardless of whether the underlying cause is CVE-2026-40976, an
+   exposure-misconfiguration in management.endpoints.web.exposure.include, a
+   reverse-proxy mis-routing, or a future regression of similar shape.
+
+   Both rules are body-content rules — match on captured HTTP response
+   payloads (WAF body capture, tcpdump/PCAP, mirrored egress traffic).
+
+   References:
+     - https://spring.io/security/cve-2026-40976/
+     - https://github.com/spring-projects/spring-boot/commit/874f6294b91da18367b8b5ab7b2fad3fa23cfba6
+     - https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.heapdump
+     - https://binautopsy.com/research/cve-2026-40976/
+
+   Author: Binautopsy Labs (defensive analysis brief)
+   Created: 2026-04-28
+*/
+
+rule EXPL_Spring_Boot_HPROF_Egress_Apr26_1 {
+   meta:
+      description = "Detects a Java HPROF heap dump in an HTTP response body — typically an unauthenticated /actuator/heapdump exfiltration. CVE-AGNOSTIC: any Spring deployment streaming HPROF to an off-host client is in trouble regardless of the specific advisory."
+      author = "Binautopsy Labs"
+      reference = "https://binautopsy.com/research/cve-2026-40976/"
+      date = "2026-04-28"
+      score = 75
+      id = "ad285a2e-4e3f-4347-be4f-4f8a06402a77"
+      hash1 = "JAVA PROFILE 1.0.2"
+   strings:
+      $magic_102 = "JAVA PROFILE 1.0.2"
+      $magic_101 = "JAVA PROFILE 1.0.1"
+      $magic_103 = "JAVA PROFILE 1.0.3"
+   condition:
+      filesize > 1024 and any of them at 0
+}
+
+rule EXPL_Spring_Security_Noop_Password_Egress_Apr26_1 {
+   meta:
+      description = "Detects Spring Security's {noop} PasswordEncoder marker followed by a printable-ASCII password in an HTTP response body. The {noop} prefix indicates plaintext password storage and SHOULD NEVER appear in any normal response — its presence in egress traffic is a high-fidelity credential-leak indicator. Most commonly observed in heap-dump exfiltration (CVE-2026-40976 follow-on) but generalises to any heap, log, or config-dump leak."
+      author = "Binautopsy Labs"
+      reference = "https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html#authentication-password-storage-dpe-format"
+      date = "2026-04-28"
+      score = 70
+      id = "70d594d5-33b9-4a8f-8183-7726f679dbf1"
+   strings:
+      $marker = /\{noop\}[\x21-\x7e]{4,200}/
+   condition:
+      $marker
+}


### PR DESCRIPTION
# Add Spring Boot Actuator egress detection rules (CVE-2026-40976 + general)

## Summary

This PR adds two CVE-AGNOSTIC YARA rules in `yara/expl_spring_boot_actuator_egress_apr26.yar`.

| Rule | What it matches | Score |
|---|---|---|
| `EXPL_Spring_Boot_HPROF_Egress_Apr26_1` | Java HPROF magic bytes (`JAVA PROFILE 1.0.[123]`) at offset 0 of a body ≥ 1KB | 75 |
| `EXPL_Spring_Security_Noop_Password_Egress_Apr26_1` | `{noop}<plaintext-password>` in any response body | 70 |

## Coverage rationale

Motivated by CVE-2026-40976 (Spring Boot 4.0.0–4.0.5 actuator authorization
bypass) but **deliberately not scoped to that CVE**:

- **Rule 1 (HPROF magic)** fires on any heap-dump exfiltration: anonymous
  `/actuator/heapdump` access under CVE-2026-40976, misconfigured
  `management.endpoints.web.exposure.include=*` deployments,
  reverse-proxy routing accidents, or any future regression of similar
  shape. `JAVA PROFILE 1.0.x` should not appear in normal HTTP egress.
- **Rule 2 (`{noop}` marker)** fires on any heap, log, or config dump
  containing Spring Security's plaintext-password marker. The marker
  should never appear in normal response bodies; its egress is a
  high-fidelity credential-leak indicator regardless of the underlying
  cause.

## Why these are body-content rules

Both rules target captured HTTP response payloads (WAF body capture,
PCAP, mirrored egress). Filename-content rules wouldn't catch in-flight
exfiltration; the rules need to apply at the egress observation point.

## Why score 70/75 (not 100)

- **HPROF rule (75):** The magic-bytes match is unambiguous, but legitimate
  heap-dump captures by SRE / APM tools exist. The score reflects "very
  likely malicious in the absence of a known operator allowlist" rather
  than "deterministic hit". Operators can raise locally if their
  environment never permits heap-dump egress.
- **`{noop}` marker rule (70):** Slightly conservative because the marker
  could in principle appear in a malware sample's payload that's
  imitating Spring Security strings. The realistic-FP rate is very low
  but not zero.

## References

- [CVE-2026-40976 — Spring Security Advisory](https://spring.io/security/cve-2026-40976/)
- [Patch commit `874f6294b9`](https://github.com/spring-projects/spring-boot/commit/874f6294b91da18367b8b5ab7b2fad3fa23cfba6)
- [Spring Security DelegatingPasswordEncoder format spec](https://docs.spring.io/spring-security/reference/features/authentication/password-storage.html#authentication-password-storage-dpe-format)
- [Spring Boot heapdump endpoint documentation](https://docs.spring.io/spring-boot/reference/actuator/endpoints.html#actuator.endpoints.heapdump)
- [Binautopsy Labs research writeup](https://binautopsy.com/research/cve-2026-40976/)

## Validation

- Both rules compile cleanly with `yara -v` ≥ 4.x.
- Tested against the HPROF binary captured from a CVE-2026-40976 lab
  (rule 1 fires); tested against a 1MB random-bytes file (does not fire).
- Tested rule 2 against a heap-dump string-extract containing
  `{noop}lab-admin-password-not-real` (fires); against a representative
  baseline of legitimate Spring Boot response bodies (zero hits).

## Notes

- Both rules use the `expl_<topic>_<date>_N` naming convention used
  elsewhere in `yara/`. If a different placement is preferred (e.g.,
  generic_<...>_<topic>) please advise.
- The rules are CVE-AGNOSTIC by design — they catch the regression class,
  not just CVE-2026-40976. The filename intentionally does not contain
  the CVE ID.
