### PR TITLE
Add Arsenal-237 ransomware suite + BYOVD toolkit detection (47 rules)

### DIFF
--- a/iocs/hash-iocs.txt
+++ b/iocs/hash-iocs.txt
@@ -3376,3 +3376,11 @@ aea55e42c4436236278e5692d3dcbcbe5fe6ce0b;DAEMON Tools Lite supplychain compromis
 2d4eb55b01f59c62c6de9aacba9b47267d398fe4;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
 9dbfc23ebf36b3c0b56d2f93116abb32656c42e4;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
 295ce86226b933e7262c2ce4b36bdd6c389aaaef;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
+
+47ec51b5f0ede1e70bd66f3f0152f9eb536d534565dbb7fcc3a05f542dbe4428;Arsenal-237 BdApiUtil64.sys BYOVD driver
+c4dda7b5c5f6eab49efc86091377ab08275aa951d956a5485665954830d1267e;Arsenal-237 local privilege escalation tool
+d73c4f127c5c0a7f9bf0f398e95dd55c7e8f6f6a5783c8cb314bd99c2d1c9802;Arsenal-237 ransomware decryptor dec_fixed.exe
+158f61b6d10ea2ce78769703a2ffbba9c08f0172e37013de960d9efe5e9fde14;Arsenal-237 nethost.dll C2 module
+613d4d0f1612686742889e834ebc9ebff6ae021cf81a4c50f66369195ca01899;Arsenal-237 ransomware enc_c2.exe
+4d1fe7b54a0ce9ce2082c167b662ec138b890e3f305e67bdc13a5e9a24708518;Arsenal-237 ransomware full_test_enc.exe
+90d223b70448d68f7f48397df6a9e57de3a6b389d5d8dc0896be633ca95720f2;Arsenal-237 ransomware new_enc.exe

--- a/yara/mal_arsenal237_byovd_toolkit.yar
+++ b/yara/mal_arsenal237_byovd_toolkit.yar
@@ -6,24 +6,6 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
-rule Arsenal237_BdApiUtil64_Hash {
-   meta:
-      description = "Detects Arsenal-237 BdApiUtil64.sys by file hash - BYOVD weaponized Baidu Antivirus kernel driver"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-BdApiUtil64-sys/"
-      date = "2026-01-26"
-      hash1 = "47ec51b5f0ede1e70bd66f3f0152f9eb536d534565dbb7fcc3a05f542dbe4428"
-      hash2 = "148c0cde4f2ef807aea77d7368f00f4c519f47ef"
-      hash3 = "ced47b89212f3260ebeb41682a4b95ec"
-      family = "Arsenal-237"
-      id = "9ae7cd8b-7222-580f-9578-9b97bb96395c"
-   condition:
-      hash.sha256(0, filesize) == "47ec51b5f0ede1e70bd66f3f0152f9eb536d534565dbb7fcc3a05f542dbe4428" or
-      hash.md5(0, filesize) == "ced47b89212f3260ebeb41682a4b95ec" or
-      hash.sha1(0, filesize) == "148c0cde4f2ef807aea77d7368f00f4c519f47ef"
-}
-
 rule Arsenal237_BdApiUtil_Signature {
    meta:
       description = "Detects BdApiUtil64.sys by Baidu signature strings and PDB path - BYOVD with legitimate expired certificate"
@@ -227,22 +209,6 @@ rule Arsenal237_BYOVD_Service_Creation {
       4 of ($api*) and
       $kernel_driver and
       1 of ($temp*)
-}
-
-rule Arsenal237_LPE_EXE_Hash {
-   meta:
-      description = "Detects Arsenal-237 lpe.exe by file hash - local privilege escalation wrapper with 5 independent escalation techniques"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-lpe-exe/"
-      date = "2026-01-25"
-      hash1 = "c4dda7b5c5f6eab49efc86091377ab08275aa951d956a5485665954830d1267e"
-      hash2 = "47400a6b7c84847db0513e6dbc04e469"
-      family = "Arsenal-237"
-      id = "c5f766a2-7d0c-5acf-ba85-0197cc725230"
-   condition:
-      hash.sha256(0, filesize) == "c4dda7b5c5f6eab49efc86091377ab08275aa951d956a5485665954830d1267e" or
-      hash.md5(0, filesize) == "47400a6b7c84847db0513e6dbc04e469"
 }
 
 rule Arsenal237_LPE_Token_Manipulation {

--- a/yara/mal_arsenal237_byovd_toolkit.yar
+++ b/yara/mal_arsenal237_byovd_toolkit.yar
@@ -6,6 +6,8 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
+import "hash"
+
 rule Arsenal237_BdApiUtil_Signature {
    meta:
       description = "Detects BdApiUtil64.sys by Baidu signature strings and PDB path - BYOVD with legitimate expired certificate"
@@ -208,6 +210,7 @@ rule Arsenal237_BYOVD_Service_Creation {
       uint16(0) == 0x5A4D and
       4 of ($api*) and
       $kernel_driver and
+      $driver_ext and
       1 of ($temp*)
 }
 

--- a/yara/mal_arsenal237_byovd_toolkit.yar
+++ b/yara/mal_arsenal237_byovd_toolkit.yar
@@ -1,0 +1,391 @@
+/*
+   Yara Rule Set
+   Identifier: Arsenal-237 BYOVD Toolkit (BdApiUtil64.sys, killer.dll, lpe.exe, rootkit.dll)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule Arsenal237_BdApiUtil64_Hash {
+   meta:
+      description = "Detects Arsenal-237 BdApiUtil64.sys by file hash - BYOVD weaponized Baidu Antivirus kernel driver"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-BdApiUtil64-sys/"
+      date = "2026-01-26"
+      hash1 = "47ec51b5f0ede1e70bd66f3f0152f9eb536d534565dbb7fcc3a05f542dbe4428"
+      hash2 = "148c0cde4f2ef807aea77d7368f00f4c519f47ef"
+      hash3 = "ced47b89212f3260ebeb41682a4b95ec"
+      family = "Arsenal-237"
+      id = "9ae7cd8b-7222-580f-9578-9b97bb96395c"
+   condition:
+      hash.sha256(0, filesize) == "47ec51b5f0ede1e70bd66f3f0152f9eb536d534565dbb7fcc3a05f542dbe4428" or
+      hash.md5(0, filesize) == "ced47b89212f3260ebeb41682a4b95ec" or
+      hash.sha1(0, filesize) == "148c0cde4f2ef807aea77d7368f00f4c519f47ef"
+}
+
+rule Arsenal237_BdApiUtil_Signature {
+   meta:
+      description = "Detects BdApiUtil64.sys by Baidu signature strings and PDB path - BYOVD with legitimate expired certificate"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-BdApiUtil64-sys/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "4664f9f5-adfc-578e-a849-4d8bb31d97f2"
+   strings:
+      $pdb = "D:\\jenkins\\workspace\\bav_5.0_workspace\\BavOutput\\Pdb\\Release\\BdApiUtil64.pdb" ascii wide
+      $signer = "Baidu Online Network Technology" ascii wide
+      $product = "Baidu Antivirus" ascii wide
+      $device = "\\Device\\BdApiUtil" ascii wide
+      $service = "Bprotect" ascii wide
+      $callback = "bdProtectExpCallBack" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      uint32(uint32(0x3C)) == 0x00004550 and
+      (2 of ($*))
+}
+
+rule Arsenal237_BdApiUtil_IOCTL_Abuse {
+   meta:
+      description = "Detects malware using BdApiUtil64.sys IOCTL codes for process termination and SSDT bypass"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-BdApiUtil64-sys/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "ade3b9f5-c841-5cf8-8266-a95ea8f4956d"
+   strings:
+      $ioctl1 = { B4 24 00 80 }
+      $ioctl2 = { B8 24 00 80 }
+      $ioctl3 = { 24 23 00 80 }
+      $ioctl4 = { 48 26 00 80 }
+      $ioctl5 = { 4C 26 00 80 }
+      $api = "DeviceIoControl" ascii wide
+      $device = "\\\\.\\BdApiUtil" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      $api and $device and
+      2 of ($ioctl*)
+}
+
+rule Arsenal237_BdApiUtil_SSDT_Bypass {
+   meta:
+      description = "Detects SSDT bypass implementation using KeServiceDescriptorTable resolution via BdApiUtil64.sys"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-BdApiUtil64-sys/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "cd77a3e2-7c9a-5c73-8433-bdc0cf40783c"
+   strings:
+      $ssdt_string = "KeServiceDescriptorTable" ascii wide
+      $api1 = "MmGetSystemRoutineAddress" ascii wide
+      $api2 = "RtlInitUnicodeString" ascii wide
+      $hook_check = { 80 3? B8 }
+      $ssdt_lookup = { 8B ?? ?? C1 E? 02 }
+   condition:
+      uint16(0) == 0x5A4D and
+      $ssdt_string and
+      all of ($api*) and
+      1 of ($hook_check, $ssdt_lookup)
+}
+
+rule Arsenal237_BdApiUtil_Kernel_Termination {
+   meta:
+      description = "Detects kernel-mode process termination targeting security products via BdApiUtil64.sys"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-BdApiUtil64-sys/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "727bfa59-0321-5854-a6d1-b447cacc81f8"
+   strings:
+      $api1 = "PsLookupProcessByProcessId" ascii
+      $api2 = "ZwTerminateProcess" ascii
+      $api3 = "ObOpenObjectByPointer" ascii
+      $api4 = "ObDereferenceObject" ascii
+      $target1 = "MsMpEng.exe" ascii wide nocase
+      $target2 = "CSFalconService.exe" ascii wide nocase
+      $target3 = "ekrn.exe" ascii wide nocase
+      $target4 = "avp.exe" ascii wide nocase
+   condition:
+      uint16(0) == 0x5A4D and
+      3 of ($api*) and
+      2 of ($target*)
+}
+
+rule Arsenal237_Killer_DLL_BYOVD_Comprehensive {
+   meta:
+      description = "Detects Arsenal-237 killer.dll BYOVD defense evasion module with embedded BdApiUtil64.sys and ProcExpDriver.sys for security product termination"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-killer-dll/"
+      date = "2026-01-25"
+      hash1 = "10eb1fbb2be3a09eefb3d97112e42bb06cf029e6cac2a9fb891b8b89a25c788d"
+      family = "Arsenal-237"
+      id = "e2daec7c-79e6-5f1f-bf86-ae557249ae73"
+   strings:
+      $baidu_driver1 = "BdApiUtil64.sys" ascii wide nocase
+      $baidu_driver2 = "Baidu Antivirus BdApi Driver" ascii wide
+      $baidu_company = "Baidu, Inc." ascii wide
+      $baidu_device = "\\\\.\\BdApiUtil" ascii wide
+      $procexp_driver1 = "ProcExpDriver.sys" ascii wide nocase
+      $procexp_driver2 = "PROCEXP152" ascii wide
+      $procexp_company = "Sysinternals - www.sysinternals.com" ascii wide
+      $procexp_device = "\\\\.\\PROCEXP152" ascii wide
+      $ioctl_baidu = { B4 24 00 80 }
+      $ioctl_procexp = { 3C 00 35 83 }
+      $target1 = "MsMpEng.exe" ascii wide nocase
+      $target2 = "ekrn.exe" ascii wide nocase
+      $target3 = "avp.exe" ascii wide nocase
+      $target4 = "MBAMService.exe" ascii wide nocase
+      $target5 = "bdservicehost.exe" ascii wide nocase
+      $svc1 = "CreateServiceW" ascii wide
+      $svc2 = "StartServiceW" ascii wide
+      $svc3 = "DeleteService" ascii wide
+      $svc4 = "NtUnloadDriver" ascii wide
+      $rust1 = "rustc" ascii
+      $rust2 = "/rustc/" ascii
+      $c2_ip = "109.230.231.37" ascii wide
+      $export_func = "get_hostfxr_path" ascii
+      $mz = { 4D 5A }
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      hash.sha256(0, filesize) == "10eb1fbb2be3a09eefb3d97112e42bb06cf029e6cac2a9fb891b8b89a25c788d" or
+      (
+      (#mz >= 2) and
+      (2 of ($baidu_*)) and
+      (2 of ($procexp_*)) and
+      (1 of ($ioctl_*))
+      ) or
+      (
+      (3 of ($target*)) and
+      (2 of ($svc*)) and
+      (1 of ($ioctl_*)) and
+      (1 of ($baidu_*, $procexp_*))
+      ) or
+      (
+      ($c2_ip) and
+      ($export_func) and
+      (1 of ($rust*)) and
+      (2 of ($target*))
+      )
+      )
+}
+
+rule Arsenal237_Embedded_Vulnerable_Driver {
+   meta:
+      description = "Detects embedded BdApiUtil64.sys or ProcExpDriver.sys within files indicating BYOVD payload staging"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-killer-dll/"
+      date = "2026-01-25"
+      family = "Arsenal-237"
+      id = "6a4f6f6d-a38d-52ed-a339-fae826652b26"
+   strings:
+      $baidu_full1 = "\\SystemRoot\\System32\\Drivers\\BdApiUtil64.sys" ascii wide nocase
+      $baidu_full2 = "Baidu Antivirus BdApi Driver" ascii wide
+      $baidu_version = "5.0.3.84333" ascii wide
+      $procexp_full1 = "\\SystemRoot\\System32\\Drivers\\PROCEXP152.SYS" ascii wide nocase
+      $procexp_full2 = "Process Explorer" ascii wide
+      $procexp_version = "17.0.7" ascii wide
+      $device_baidu = "\\\\.\\BdApiUtil" ascii wide
+      $device_procexp = "\\\\.\\PROCEXP152" ascii wide
+      $mz = { 4D 5A }
+   condition:
+      #mz >= 2 and
+      (
+      (2 of ($baidu_*)) or
+      (2 of ($procexp_*)) or
+      (1 of ($device_*) and #mz >= 2)
+      )
+}
+
+rule Arsenal237_BYOVD_Service_Creation {
+   meta:
+      description = "Detects BYOVD service creation patterns for kernel driver deployment (memory scanning use case)"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-killer-dll/"
+      date = "2026-01-25"
+      family = "Arsenal-237"
+      id = "729b1f2b-6e8c-51f8-9feb-4225ab8b5f14"
+   strings:
+      $api1 = "OpenSCManagerW" ascii wide
+      $api2 = "CreateServiceW" ascii wide
+      $api3 = "StartServiceW" ascii wide
+      $api4 = "ControlService" ascii wide
+      $api5 = "DeleteService" ascii wide
+      $kernel_driver = "SERVICE_KERNEL_DRIVER" ascii wide
+      $driver_ext = ".sys" ascii wide nocase
+      $temp1 = "\\AppData\\Local\\Temp\\" ascii wide nocase
+      $temp2 = "\\Windows\\Temp\\" ascii wide nocase
+   condition:
+      uint16(0) == 0x5A4D and
+      4 of ($api*) and
+      $kernel_driver and
+      1 of ($temp*)
+}
+
+rule Arsenal237_LPE_EXE_Hash {
+   meta:
+      description = "Detects Arsenal-237 lpe.exe by file hash - local privilege escalation wrapper with 5 independent escalation techniques"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-lpe-exe/"
+      date = "2026-01-25"
+      hash1 = "c4dda7b5c5f6eab49efc86091377ab08275aa951d956a5485665954830d1267e"
+      hash2 = "47400a6b7c84847db0513e6dbc04e469"
+      family = "Arsenal-237"
+      id = "c5f766a2-7d0c-5acf-ba85-0197cc725230"
+   condition:
+      hash.sha256(0, filesize) == "c4dda7b5c5f6eab49efc86091377ab08275aa951d956a5485665954830d1267e" or
+      hash.md5(0, filesize) == "47400a6b7c84847db0513e6dbc04e469"
+}
+
+rule Arsenal237_LPE_Token_Manipulation {
+   meta:
+      description = "Detects Arsenal-237 lpe.exe token impersonation API pattern targeting SYSTEM-level processes"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-lpe-exe/"
+      date = "2026-01-25"
+      family = "Arsenal-237"
+      id = "b3e63cd7-eb13-5f0d-ac24-a89c0c56aa01"
+   strings:
+      $api1 = "CreateToolhelp32Snapshot" ascii wide
+      $api2 = "OpenProcessToken" ascii wide
+      $api3 = "DuplicateTokenEx" ascii wide
+      $api4 = "ImpersonateLoggedOnUser" ascii wide
+      $api5 = "Process32FirstW" ascii wide
+      $api6 = "Process32NextW" ascii wide
+      $process1 = "winlogon.exe" ascii wide nocase
+      $process2 = "lsass.exe" ascii wide nocase
+      $process3 = "services.exe" ascii wide nocase
+      $process4 = "csrss.exe" ascii wide nocase
+   condition:
+      uint16(0) == 0x5A4D and
+      all of ($api*) and
+      2 of ($process*)
+}
+
+rule Arsenal237_LPE_UAC_Bypass {
+   meta:
+      description = "Detects Arsenal-237 lpe.exe UAC bypass via fodhelper.exe registry hijack"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-lpe-exe/"
+      date = "2026-01-25"
+      family = "Arsenal-237"
+      id = "ec1c0013-93e9-5955-b94e-1cc409fe54d9"
+   strings:
+      $reg1 = "HKCU\\\\Software\\\\Classes\\\\ms-settings\\\\Shell\\\\Open\\\\command" ascii wide nocase
+      $reg2 = "DelegateExecute" ascii wide
+      $reg3 = "reg add" ascii wide nocase
+      $reg4 = "fodhelper.exe" ascii wide nocase
+      $reg5 = "reg delete" ascii wide nocase
+   condition:
+      uint16(0) == 0x5A4D and
+      all of ($reg*)
+}
+
+rule Arsenal237_LPE_Named_Pipe {
+   meta:
+      description = "Detects Arsenal-237 lpe.exe named pipe impersonation via Print Spooler exploitation"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-lpe-exe/"
+      date = "2026-01-25"
+      family = "Arsenal-237"
+      id = "558d33dd-996c-546c-9519-c849dd4d05d9"
+   strings:
+      $pipe1 = "CreateNamedPipeW" ascii wide
+      $pipe2 = "ImpersonateNamedPipeClient" ascii wide
+      $pipe3 = "ConnectNamedPipe" ascii wide
+      $pipe4 = "\\\\\\\\.\\\\pipe\\\\" ascii wide
+      $pipe5 = "spoolss" ascii wide nocase
+      $ps = "powershell" ascii wide nocase
+      $ps_pipe = "NamedPipeClientStream" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      (all of ($pipe*) or ($ps and $ps_pipe))
+}
+
+rule Arsenal237_LPE_Schtasks {
+   meta:
+      description = "Detects Arsenal-237 lpe.exe scheduled task escalation using schtasks.exe with SYSTEM context"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-lpe-exe/"
+      date = "2026-01-25"
+      family = "Arsenal-237"
+      id = "89cb74a1-93b5-5838-90e5-802877519e40"
+   strings:
+      $schtasks1 = "schtasks" ascii wide nocase
+      $schtasks2 = "/create" ascii wide nocase
+      $schtasks3 = "/tn" ascii wide nocase
+      $schtasks4 = "/ru SYSTEM" ascii wide nocase
+      $schtasks5 = "/delete" ascii wide nocase
+   condition:
+      uint16(0) == 0x5A4D and
+      all of ($schtasks*)
+}
+
+rule Arsenal237_Rootkit_DLL_Comprehensive {
+   meta:
+      description = "Detects Arsenal-237 rootkit.dll Rust-compiled defense evasion framework targeting 20+ security products via BYOVD"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-rootkit-dll/"
+      date = "2026-01-27"
+      hash1 = "e71240f26af1052172b5864cdddb78fcb990d7a96d53b7d22d19f5dfccdf9012"
+      hash2 = "483feeb4e391ae64a7d54637ea71d43a17d83c71"
+      hash3 = "674795d4d4ec09372904704633ea0d86"
+      family = "Arsenal-237"
+      id = "01bb7447-f2bd-5538-a989-582b4762f581"
+   strings:
+      $rust_panic = "panicked at" ascii
+      $rust_runtime = "std::panicking::rust_panic" ascii
+      $rust_thread = "std::thread::Builder" ascii
+      $baidu_driver_1 = "BdApiUtil64.sys" wide ascii
+      $baidu_driver_2 = "Baidu" wide ascii nocase
+      $defender_1 = "MsMpEng.exe" wide ascii nocase
+      $defender_2 = "MpCmdRun.exe" wide ascii nocase
+      $defender_3 = "SecurityHealthService.exe" wide ascii nocase
+      $defender_4 = "WdNisDrv.sys" wide ascii nocase
+      $defender_5 = "WdFilter.sys" wide ascii nocase
+      $crowdstrike_1 = "CSFalconService.exe" wide ascii nocase
+      $crowdstrike_2 = "CSFalconContainer.exe" wide ascii nocase
+      $crowdstrike_3 = "csagent.sys" wide ascii nocase
+      $av_eset = "ekrn.exe" wide ascii nocase
+      $av_kaspersky = "avp.exe" wide ascii nocase
+      $av_malwarebytes = "MBAMService.exe" wide ascii nocase
+      $av_symantec = "ccSvcHst.exe" wide ascii nocase
+      $av_webroot = "WRSA.exe" wide ascii nocase
+      $av_sophos = "SophosHealth.exe" wide ascii nocase
+      $av_cylance = "CylanceSvc.exe" wide ascii nocase
+      $av_sentinel = "SentinelAgent.exe" wide ascii nocase
+      $analysis_1 = "procexp.exe" wide ascii nocase
+      $analysis_2 = "procmon.exe" wide ascii nocase
+      $analysis_3 = "Wireshark.exe" wide ascii nocase
+      $analysis_4 = "x64dbg.exe" wide ascii nocase
+      $analysis_5 = "volatility.exe" wide ascii nocase
+      $func_dispatcher = { 48 83 EC 28 48 8B ?? 48 8B ?? 48 8B ?? 48 85 ?? 74 ?? FF D? }
+      $func_thread_create = { 48 89 5C 24 ?? 48 89 74 24 ?? 57 48 83 EC 20 48 8B D9 }
+      $api_terminate = "ZwTerminateProcess" ascii
+      $api_openprocess = "OpenProcess" ascii
+      $api_createthread = "CreateThread" ascii
+      $api_loaddriver = "ZwLoadDriver" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      (
+      (2 of ($rust_*) and 1 of ($baidu_*)) or
+      (6 of ($defender_*, $crowdstrike_*, $av_*)) or
+      (3 of ($analysis_*)) or
+      (1 of ($func_*) and 2 of ($api_*)) or
+      (1 of ($rust_*) and 3 of ($defender_*, $crowdstrike_*, $av_*) and 1 of ($func_*))
+      )
+}

--- a/yara/mal_arsenal237_ransomware.yar
+++ b/yara/mal_arsenal237_ransomware.yar
@@ -1,0 +1,693 @@
+/*
+   Yara Rule Set
+   Identifier: Arsenal-237 Ransomware Suite (enc_c2, new_enc, full_test_enc, dec_fixed, nethost, chromelevator)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule Chromelevator_Browser_Credential_Extraction {
+   meta:
+      description = "Detects Arsenal-237 chromelevator.exe browser credential extraction tool targeting Chrome, Brave, and Edge via reflective DLL injection"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-chromelevator-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "6b23aa0e-8604-538e-9dbd-5b70fd18bd65"
+   strings:
+      $filename = "chromelevator.exe" nocase ascii
+      $payload = "PAYLOAD_DLL" nocase ascii
+      $chrome = "chrome.exe" nocase ascii
+      $brave = "brave.exe" nocase ascii
+      $edge = "msedge.exe" nocase ascii
+      $named_pipe = "Named pipe server created" nocase ascii
+      $reflective = "ReflectiveLoader" nocase ascii
+      $extraction = "Extracted" nocase ascii
+      $cookies = "cookies" nocase ascii
+      $passwords = "passwords" nocase ascii
+      $payments = "payments" nocase ascii
+      $verbose = "--verbose" nocase ascii
+      $fingerprint = "--fingerprint" nocase ascii
+      $output = "--output-path" nocase ascii
+      $create_pipe = "CreateNamedPipeW" nocase ascii
+      $connect_pipe = "ConnectNamedPipe" nocase ascii
+      $find_resource = "FindResourceW" nocase ascii
+      $load_resource = "LoadResource" nocase ascii
+   condition:
+      ($filename and $payload and ($extraction or ($cookies and $passwords))) or
+      (3 of ($chrome, $brave, $edge) and 2 of ($extraction, $cookies, $passwords)) or
+      ($reflective and $named_pipe and any of ($chrome, $brave, $edge)) or
+      (2 of ($verbose, $fingerprint, $output) and any of ($chrome, $brave, $edge))
+}
+
+rule Arsenal237_Direct_Syscall_Framework {
+   meta:
+      description = "Detects Arsenal-237 direct syscall EDR bypass framework using Zw* Native API calls to avoid EDR hooking"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-chromelevator-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "4eb2e9e0-7633-5af4-8a6e-ee93245b6f23"
+   strings:
+      $zw_alloc = "ZwAllocateVirtualMemory" nocase ascii
+      $zw_write = "ZwWriteVirtualMemory" nocase ascii
+      $zw_read = "ZwReadVirtualMemory" nocase ascii
+      $zw_protect = "ZwProtectVirtualMemory" nocase ascii
+      $zw_create_thread = "ZwCreateThreadEx" nocase ascii
+      $zw_open_proc = "ZwOpenProcess" nocase ascii
+      $zw_query_proc = "ZwQueryInformationProcess" nocase ascii
+      $zw_context = "ZwGetContextThread" nocase ascii
+      $zw_set_context = "ZwSetContextThread" nocase ascii
+      $zw_resume = "ZwResumeThread" nocase ascii
+      $zw_pattern = /Zw[A-Z][a-zA-Z]+/
+   condition:
+      (5 of ($zw_alloc, $zw_write, $zw_protect, $zw_create_thread, $zw_open_proc)) or
+      (all of them and #zw_pattern >= 10)
+}
+
+rule Reflective_DLL_Injection_Framework {
+   meta:
+      description = "Detects reflective DLL injection implementation using ReflectiveLoader with direct syscall or Win32 API injection pattern"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-chromelevator-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "4a88262f-f5b3-568c-b25a-3f54412b4ffc"
+   strings:
+      $dos_header = "MZ" at 0
+      $reflective_loader = "ReflectiveLoader" nocase ascii
+      $reflective_export = "reflective" nocase ascii wide
+      $alloc = "VirtualAllocEx" nocase ascii
+      $write = "WriteProcessMemory" nocase ascii
+      $protect = "VirtualProtectEx" nocase ascii
+      $create_remote = "CreateRemoteThread" nocase ascii
+      $zw_alloc = "ZwAllocateVirtualMemory" nocase ascii
+      $zw_write = "ZwWriteVirtualMemory" nocase ascii
+      $zw_protect = "ZwProtectVirtualMemory" nocase ascii
+      $zw_create = "ZwCreateThreadEx" nocase ascii
+   condition:
+      ($reflective_loader and $dos_header) or
+      ($reflective_loader and all of ($zw_alloc, $zw_write, $zw_protect, $zw_create)) or
+      ($reflective_loader and all of ($alloc, $write, $protect, $create_remote))
+}
+
+rule Arsenal237_dec_fixed_FileHash {
+   meta:
+      description = "Detects Arsenal-237 dec_fixed.exe per-victim ransomware decryptor by exact cryptographic hash - recovery tool not an attack tool"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-dec_fixed-exe/"
+      date = "2026-01-26"
+      hash1 = "d73c4f127c5c0a7f9bf0f398e95dd55c7e8f6f6a5783c8cb314bd99c2d1c9802"
+      hash2 = "29014d4d6fc42219cd9cdc130b868382cf2c14c2"
+      hash3 = "7c5493a0a5df52682a5c2ba433634601"
+      family = "Arsenal-237"
+      malware_type = "Ransomware Decryptor"
+      id = "5b240e15-6f55-51b8-8f90-b3b14b9e9db8"
+   condition:
+      hash.sha256(0, filesize) == "d73c4f127c5c0a7f9bf0f398e95dd55c7e8f6f6a5783c8cb314bd99c2d1c9802" or
+      hash.md5(0, filesize) == "7c5493a0a5df52682a5c2ba433634601" or
+      hash.sha1(0, filesize) == "29014d4d6fc42219cd9cdc130b868382cf2c14c2"
+}
+
+rule Arsenal237_Victim_Key_Decryptor {
+   meta:
+      description = "Detects Arsenal-237 dec_fixed.exe victim-specific hardcoded ChaCha20 decryption key matching new_enc.exe encryption key"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-dec_fixed-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware Decryptor"
+      id = "e63e8167-3810-595e-a52d-1d85251278aa"
+   strings:
+      $key1 = "1e0d8597856270d1926cfcf252af1b14a776c20b3b50168df9311314202e73ba" nocase ascii
+      $key2 = "67e6096a85ae67bb72f36e3c3af54fa57f520e518c68059babd9831f19cde05b" nocase ascii
+   condition:
+      1 of them
+}
+
+rule Arsenal237_ChaCha20_Decryption {
+   meta:
+      description = "Detects Arsenal-237 dec_fixed.exe ChaCha20-Poly1305 AEAD decryption implementation with key validation error strings"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-dec_fixed-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware Decryptor"
+      id = "fd58d054-fcba-5acb-9fc2-3b8760897fba"
+   strings:
+      $constant1 = "expand 32-byte k" ascii nocase
+      $error1 = "Decryption failed - wrong key or corrupted file" ascii
+      $error2 = "File corrupted - encrypted size mismatch" ascii
+   condition:
+      $constant1 and any of ($error1, $error2)
+}
+
+rule Arsenal237_Decryptor_Tool {
+   meta:
+      description = "Detects Arsenal-237 dec_fixed.exe batch file decryptor with --folder-a parameter and characteristic error message strings"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-dec_fixed-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware Decryptor"
+      id = "1eaf0468-4677-509b-b617-76b521e34965"
+   strings:
+      $cmd1 = "--folder-a" ascii
+      $error1 = "File too small" ascii
+      $error2 = "Could not find filename" ascii
+      $error3 = "Invalid victim key hex" ascii
+      $cleanup = "readme.txt" ascii nocase
+   condition:
+      $cmd1 and 2 of ($error1, $error2, $error3) and $cleanup
+}
+
+rule Arsenal237_Rust_Compiled_Tools {
+   meta:
+      description = "Detects Arsenal-237 Rust-compiled ransomware tools (encryptors and decryptors) by ChaCha20-Poly1305 library strings and file size"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-dec_fixed-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "2d681148-fb9f-57ed-9cb7-b5e46330976c"
+   strings:
+      $chacha20_lib = "chacha20" ascii nocase
+      $poly1305_lib = "poly1305" ascii nocase
+      $rust_constant = "expand 32-byte k" ascii
+      $rust_error = "Decryption failed" ascii nocase
+   condition:
+      filesize > 900KB and filesize < 1MB and
+      $chacha20_lib and $poly1305_lib and
+      $rust_constant
+}
+
+rule Arsenal237_nethost_FileHash {
+   meta:
+      description = "Detects Arsenal-237 nethost.dll C2 communication module by file hash - Rust DLL hijacking persistence targeting .NET host library"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-nethost-dll/"
+      date = "2026-01-26"
+      hash1 = "158f61b6d10ea2ce78769703a2ffbba9c08f0172e37013de960d9efe5e9fde14"
+      hash2 = "622ddbacaf769aef383435162a203489c08c8468"
+      hash3 = "f91ff1bb5699524524fff0e2587af040"
+      family = "Arsenal-237"
+      malware_type = "C2 Communication Module"
+      id = "f3063e07-ac28-5aac-8f6e-159e27d5944f"
+   condition:
+      hash.sha256(0, filesize) == "158f61b6d10ea2ce78769703a2ffbba9c08f0172e37013de960d9efe5e9fde14" or
+      hash.md5(0, filesize) == "f91ff1bb5699524524fff0e2587af040" or
+      hash.sha1(0, filesize) == "622ddbacaf769aef383435162a203489c08c8468"
+}
+
+rule Arsenal237_nethost_C2_Strings {
+   meta:
+      description = "Detects Arsenal-237 nethost.dll by hardcoded C2 target strings and environment variable discovery concatenation artifact"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-nethost-dll/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "C2 Communication Module"
+      id = "93e82bff-7142-5af5-9328-ed4a5beb337c"
+   strings:
+      $c2_targets = "8.8.8.8:53127.0.0.1ntdll.dll" ascii
+      $env_discovery = "COMPUTERNAMEUSERNAME" ascii
+      $rust_panic = "runtime error" ascii
+      $winsock_init = "WSAStartup" ascii
+   condition:
+      ($c2_targets or $env_discovery) and uint16(0) == 0x5A4D
+}
+
+rule Arsenal237_nethost_PowerShell_Templates {
+   meta:
+      description = "Detects Arsenal-237 nethost.dll embedded PowerShell command templates for service enumeration, file download, and C2 response parsing"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-nethost-dll/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "C2 Communication Module"
+      id = "635cb72c-b596-58ad-b496-fa3bfc721760"
+   strings:
+      $ps_service = "Get-Service|?{$_.Status -eq ''}" ascii
+      $ps_download = "Invoke-WebRequest -Uri '' -OutFile ''" ascii
+      $upload_prefix = "pathB64:" ascii
+      $response_keywords = "resultmachine_idsuccess" ascii
+   condition:
+      3 of them and uint16(0) == 0x5A4D
+}
+
+rule Arsenal237_nethost_Winsock_Init {
+   meta:
+      description = "Detects Arsenal-237 nethost.dll Winsock 2.2 initialization pattern with WSASocket and environment variable enumeration"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-nethost-dll/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "C2 Communication Module"
+      id = "b4d7182c-cf4c-539e-80fc-c083b175e543"
+   strings:
+      $ws_startup = { C7 ?? ?? 02 02 00 }
+      $wsa_socket = "WSASocket" ascii
+      $connect_api = "connect" ascii
+      $env_vars = "COMPUTERNAME" ascii
+   condition:
+      all of them and uint16(0) == 0x5A4D
+}
+
+rule Arsenal237_nethost_Rust_Indicators {
+   meta:
+      description = "Detects Arsenal-237 nethost.dll Rust compilation indicators including panic handler and standard library artifacts"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-nethost-dll/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "C2 Communication Module"
+      id = "4620a235-bc72-5683-8f84-3d0f1a499364"
+   strings:
+      $rust_panic = "rust_panic" ascii
+      $rustc_artifact = ".rustc_artifact" ascii
+      $rust_std = "std::panic" ascii
+      $assertion_fail = "assertion `left  right` failed" ascii
+   condition:
+      2 of them and uint16(0) == 0x5A4D
+}
+
+rule Arsenal237_enc_c2_FileHash {
+   meta:
+      description = "Detects Arsenal-237 enc_c2.exe Rust-compiled ransomware by file hash - Tor C2 with ChaCha20 encryption"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      hash1 = "613d4d0f1612686742889e834ebc9ebff6ae021cf81a4c50f66369195ca01899"
+      hash2 = "34d3c75e79633eb3bf47e751fb31274760aeae09"
+      hash3 = "32a3497e57604e1037f1ff9993a8fdaa"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "bd988044-c636-5d46-8fde-607527b38cde"
+   condition:
+      hash.sha256(0, filesize) == "613d4d0f1612686742889e834ebc9ebff6ae021cf81a4c50f66369195ca01899" or
+      hash.md5(0, filesize) == "32a3497e57604e1037f1ff9993a8fdaa" or
+      hash.sha1(0, filesize) == "34d3c75e79633eb3bf47e751fb31274760aeae09"
+}
+
+rule Arsenal237_ChaCha20_Encryption_Constants {
+   meta:
+      description = "Detects ChaCha20 cipher implementation used by Arsenal-237 enc_c2.exe ransomware for file encryption"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "b7c172f4-76e9-52ec-a00c-2d8e5e960766"
+   strings:
+      $chacha_constant_1 = "expand 32-byte k" ascii
+      $chacha_constant_2 = "Chacha_256_constant" ascii
+      $chacha_library = "aead-0.5.2" ascii
+      $chacha_function = "chacha20" ascii nocase
+   condition:
+      any of them
+}
+
+rule Arsenal237_Tor_C2_Infrastructure {
+   meta:
+      description = "Detects Arsenal-237 enc_c2.exe Tor hidden service C2 domain and beacon endpoint strings"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware C2"
+      id = "c43947ba-6b5e-56a6-9187-c59ee9ec5ad2"
+   strings:
+      $c2_domain = "rustydl5ak6p6ajqnja6qzkxvp5huhe4olpdsq5oy75ea4o34aalpkqd.onion" ascii
+      $c2_endpoint = "/c2/beacon.php" ascii
+      $c2_protocol = "POST /c2/beacon.php" ascii
+      $onion_tld = ".onion" ascii
+   condition:
+      any of them
+}
+
+rule Arsenal237_Ransomware_Operations {
+   meta:
+      description = "Detects Arsenal-237 enc_c2.exe ransomware operational strings including encryption markers and ransom note generation"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "0fce6789-e5c8-5645-bb11-5469d4059a78"
+   strings:
+      $ransom_msg = "YOUR FILES HAVE BEEN ENCRYPTED!" ascii
+      $ransom_note = "README.txt" ascii
+      $encrypted_extension = ".locked" ascii
+      $enc_c2_executable = "enc_c2.exe" ascii
+      $http_client = "ureq" ascii
+   condition:
+      3 of them
+}
+
+rule Arsenal237_TEB_AntiDebug {
+   meta:
+      description = "Detects TEB-based anti-debugging technique used by Arsenal-237 enc_c2.exe with sleep-based sandbox evasion"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "d4cfca14-ca09-571f-9ba8-7a11250d51bc"
+   strings:
+      $teb_api = "NtCurrentTeb" ascii
+      $stack_base = "StackBase" ascii
+      $sleep_loop = { 68 88 13 00 00 FF 15 }
+      $sleep_1000 = { 68 E8 03 00 00 FF 15 }
+   condition:
+      ($teb_api and ($sleep_loop or $sleep_1000))
+}
+
+rule Arsenal237_Rust_Compilation_Artifacts {
+   meta:
+      description = "Detects Rust compiler and Cargo registry artifacts in Arsenal-237 malware binaries"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      id = "f58d1418-f733-5cdb-b069-ce296e254486"
+   strings:
+      $rust_lib_path = "/root/.cargo/registry/src/" ascii
+      $crates_io = "index.crates.io" ascii
+      $rustc = "rustc" ascii
+      $rust_std = "std" ascii
+   condition:
+      2 of them
+}
+
+rule Arsenal237_RaaS_Builder_Tracking {
+   meta:
+      description = "Detects Arsenal-237 RaaS builder ID strings and affiliate tracking markers in ransomware samples"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "RaaS"
+      id = "151bd2c3-586a-5444-9d66-62bfddd9df33"
+   strings:
+      $builder_id_default = "TEST_BUILD_001" ascii
+      $builder_id_generic = "builder_id" ascii
+      $victim_id = "victim_id" ascii
+      $encryption_key = "encryption_key" ascii
+      $machine_info = "machine_info" ascii
+   condition:
+      (($builder_id_default and $builder_id_generic) or
+      ($builder_id_generic and $encryption_key and $victim_id and $machine_info))
+}
+
+rule Arsenal237_FullTestEnc_FileHash {
+   meta:
+      description = "Detects Arsenal-237 full_test_enc.exe by exact cryptographic hash - advanced Rust ransomware with ChaCha20+RSA and parallel encryption"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
+      date = "2026-01-27"
+      hash1 = "4d1fe7b54a0ce9ce2082c167b662ec138b890e3f305e67bdc13a5e9a24708518"
+      hash2 = "bc0788a36b6b839fc917be0577cd14e584c71fd8"
+      hash3 = "1fe8b9a14f9f8435c5fb5156bcbc174e"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "80c95a71-ba72-500c-a52a-454d5780b2bc"
+   condition:
+      hash.sha256(0, filesize) == "4d1fe7b54a0ce9ce2082c167b662ec138b890e3f305e67bdc13a5e9a24708518" or
+      hash.md5(0, filesize) == "1fe8b9a14f9f8435c5fb5156bcbc174e" or
+      hash.sha1(0, filesize) == "bc0788a36b6b839fc917be0577cd14e584c71fd8"
+}
+
+rule Arsenal237_RustCrypto_ChaCha20_RSA {
+   meta:
+      description = "Detects Arsenal-237 full_test_enc.exe Rust ChaCha20 + RSA cryptographic library combination used for file encryption"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
+      date = "2026-01-27"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "2ab0cbdb-35a1-57d0-a044-bc09d26820b2"
+   strings:
+      $chacha20 = "/chacha20-0.9.1/src/lib.rs" ascii
+      $rsa = "/rsa-0.9.9/src/algorithms/" ascii
+      $aead = "/aead-0.5.2/src/lib.rs" ascii
+      $cipher = "/cipher-0.4.4/" ascii
+      $digest = "/digest-0.10.7/" ascii
+      $rand = "/rand-0.8.5/" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize > 10MB and
+      3 of them
+}
+
+rule Arsenal237_Ransomware_Lockbox_Strings {
+   meta:
+      description = "Detects Arsenal-237 full_test_enc.exe ransom messaging, .lockbox file extension, and encryption operation log strings"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
+      date = "2026-01-27"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "225bc362-de16-57fd-b8e4-7a1bb6ca6b5b"
+   strings:
+      $ransom1 = "YOUR FILES HAVE BEEN ENCRYPTED!" ascii wide
+      $ransom2 = "Ransom ID:" ascii wide
+      $lockbox = ".lockbox" ascii wide
+      $log1 = "[*] Encryptor starting..." ascii
+      $log2 = "[*] Encrypting all drives..." ascii
+      $log3 = "[+] Encryption complete!" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize > 10MB and filesize < 20MB and
+      (2 of ($ransom1, $ransom2) and $lockbox) or
+      (all of ($log1, $log2, $log3))
+}
+
+rule Arsenal237_Rayon_AntiAnalysis {
+   meta:
+      description = "Detects Arsenal-237 full_test_enc.exe Rayon parallel processing library and anti-analysis techniques including VM detection"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
+      date = "2026-01-27"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "c2193fd2-fa04-53d6-bc9d-a60963366ea2"
+   strings:
+      $rayon = "/rayon-1.11.0/src/" ascii
+      $walkdir = "/walkdir-2.5.0/" ascii
+      $sysinfo = "/sysinfo-0.29.11/" ascii
+      $vm_detect = "VMware" ascii nocase
+      $vbox_detect = "VirtualBox" ascii nocase
+      $encrypt_error1 = "Failed to encrypt nonce" ascii
+      $encrypt_error2 = "Failed to encrypt key" ascii
+      $encrypt_error3 = "Block encryption failed" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize > 10MB and
+      (all of ($rayon, $walkdir, $sysinfo)) or
+      (2 of ($vm_detect, $vbox_detect, $encrypt_error1, $encrypt_error2, $encrypt_error3))
+}
+
+rule Arsenal237_NetworkShare_Enumeration {
+   meta:
+      description = "Detects Arsenal-237 full_test_enc.exe network share enumeration via net use for lateral movement and network drive encryption"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
+      date = "2026-01-27"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "c8dba0dd-b6b8-5811-8014-e05aa2cd501a"
+   strings:
+      $netuse = "net use" ascii
+      $smb = "SMB" ascii nocase
+      $netuse_error = "Failed to execute net use" ascii
+      $folder_option = "--folder" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize > 10MB and
+      ($netuse or $netuse_error) and
+      ($folder_option or $smb)
+}
+
+rule Arsenal237_FullTestEnc_Comprehensive {
+   meta:
+      description = "Comprehensive detection for Arsenal-237 full_test_enc.exe combining Rust crypto libraries, ransom strings, and parallel encryption indicators"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
+      date = "2026-01-27"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "b0241755-d615-59f9-a689-f6c5e3d141d1"
+   strings:
+      $chacha = "/chacha20-" ascii
+      $rsa_lib = "/rsa-" ascii
+      $ransom = "YOUR FILES HAVE BEEN ENCRYPTED!" ascii wide
+      $rayon = "/rayon-" ascii
+      $walkdir = "/walkdir-" ascii
+      $sysinfo = "/sysinfo-" ascii
+      $lockbox = ".lockbox" ascii
+      $netuse = "net use" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize > 10MB and filesize < 20MB and
+      $chacha and $rsa_lib and $ransom and
+      (1 of ($rayon, $walkdir, $sysinfo)) and
+      ($lockbox or $netuse or "Ransom ID" ascii)
+}
+
+rule Arsenal237_new_enc_FileHash {
+   meta:
+      description = "Detects Arsenal-237 new_enc.exe Rust ransomware by exact file hash - human-operated ransomware with hardcoded ChaCha20 key"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      hash1 = "90d223b70448d68f7f48397df6a9e57de3a6b389d5d8dc0896be633ca95720f2"
+      hash2 = "2c01cefba27c4d3fcb3b450cb8e625e89bc54363"
+      hash3 = "a16ba61114fa5a40afce54459bbff21e"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "d2228b50-9c6e-5242-8a21-ebc3bafbeac1"
+   condition:
+      hash.sha256(0, filesize) == "90d223b70448d68f7f48397df6a9e57de3a6b389d5d8dc0896be633ca95720f2" or
+      hash.md5(0, filesize) == "a16ba61114fa5a40afce54459bbff21e" or
+      hash.sha1(0, filesize) == "2c01cefba27c4d3fcb3b450cb8e625e89bc54363"
+}
+
+rule Arsenal237_ChaCha20_Key {
+   meta:
+      description = "Detects Arsenal-237 hardcoded ChaCha20 encryption key shared between new_enc.exe and dec_fixed.exe"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "e21098a7-bae4-524b-8eb5-d9352b03e15a"
+   strings:
+      $key_hex = "67e6096a85ae67bb72f36e3c3af54fa57f520e518c68059babd9831f19cde05b" nocase ascii wide
+      $key_partial = "67e60" nocase
+   condition:
+      $key_hex or $key_partial
+}
+
+rule Arsenal237_Campaign_Identifiers {
+   meta:
+      description = "Detects Arsenal-237 new_enc.exe campaign ID, version string v0.5-beta, and RustRansomNoteTask scheduled task name"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "98ea8e65-ed23-5695-a8ed-204ccc624356"
+   strings:
+      $campaign_id = "ICIIXGD1X8ZJ4T1MTQ6TLQIDJEMDE7U4" ascii wide
+      $version = "v0.5-beta" ascii wide
+      $ransom_task = "RustRansomNoteTask" ascii wide
+   condition:
+      any of them
+}
+
+rule Arsenal237_Veritas_Backup_Targeting {
+   meta:
+      description = "Detects Arsenal-237 new_enc.exe enterprise targeting of Veritas Backup Exec and Veeam backup service processes for pre-encryption termination"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "d301b67a-2a37-5c7f-bdc3-1b9e78ce260d"
+   strings:
+      $gxvss = "GxVss" ascii wide
+      $gxblr = "GxBlr" ascii wide
+      $gxfwd = "GxFWD" ascii wide
+      $gxcvd = "GxCVD" ascii wide
+      $gxcimgr = "GxCIMgr" ascii wide
+      $veeam = "veeam" ascii wide nocase
+   condition:
+      (3 of ($gxvss, $gxblr, $gxfwd, $gxcvd, $gxcimgr)) or $veeam
+}
+
+rule Arsenal237_AntiRecovery_VSS {
+   meta:
+      description = "Detects Arsenal-237 new_enc.exe Volume Shadow Copy deletion commands to prevent ransomware recovery"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "b85772b5-03cc-551e-8475-6241ea6fcb26"
+   strings:
+      $vss_delete = "vssadmin delete shadows /all /quiet" ascii wide nocase
+      $vss_pattern = "vssadmin" ascii wide nocase
+      $delete_shadows = "delete shadows" ascii wide nocase
+   condition:
+      ($vss_delete) or ($vss_pattern and $delete_shadows)
+}
+
+rule Arsenal237_AntiAnalysis_VM_Detection {
+   meta:
+      description = "Detects Arsenal-237 new_enc.exe anti-analysis strings targeting VM environments, sandboxes, and analysis tools"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "0b1b39a6-c9b3-5462-896e-fad27cf93f9e"
+   strings:
+      $vm_vbox = "VBOX" ascii wide nocase
+      $vm_vmware = "VMWARE" ascii wide nocase
+      $vm_qemu = "QEMU" ascii wide nocase
+      $vm_xen = "XEN" ascii wide nocase
+      $vm_hyperv = "HYPERV" ascii wide nocase
+      $sandbox_cuckoo = "cuckoo" ascii wide nocase
+      $bios_registry = "HARDWARE\\DESCRIPTION\\System\\BIOS" ascii wide nocase
+      $debugger_check = "IsDebuggerPresent" ascii wide
+   condition:
+      (3 of ($vm_vbox, $vm_vmware, $vm_qemu, $vm_xen, $vm_hyperv)) or
+      $sandbox_cuckoo or $bios_registry or $debugger_check
+}
+
+rule Arsenal237_HexEncoded_RansomNote {
+   meta:
+      description = "Detects Arsenal-237 new_enc.exe hex-encoded ransom note header containing v0.5-beta version and Ransom-ID marker"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
+      date = "2026-01-26"
+      family = "Arsenal-237"
+      malware_type = "Ransomware"
+      id = "ede4cc35-bc9a-5f5e-a9d5-fdf4931202de"
+   strings:
+      $hex_header = "76302e352d626574610d0a0d0a52616e736f6d2d4944" ascii wide
+   condition:
+      $hex_header
+}

--- a/yara/mal_arsenal237_ransomware.yar
+++ b/yara/mal_arsenal237_ransomware.yar
@@ -305,7 +305,7 @@ rule Arsenal237_enc_c2_FileHash {
 
 rule Arsenal237_ChaCha20_Encryption_Constants {
    meta:
-      description = "Detects ChaCha20 cipher implementation used by Arsenal-237 enc_c2.exe ransomware for file encryption"
+      description = "Detects ChaCha20 cipher constants alongside Arsenal-237's specific aead-0.5.2 Rust crate version — combination distinguishes Arsenal-237 from generic ChaCha20 implementations (Tor, WireGuard, OpenSSL, etc.)"
       license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
       author = "The Hunters Ledger"
       reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
@@ -319,12 +319,15 @@ rule Arsenal237_ChaCha20_Encryption_Constants {
       $chacha_library = "aead-0.5.2" ascii
       $chacha_function = "chacha20" ascii nocase
    condition:
-      any of them
+      uint16(0) == 0x5A4D and
+      filesize < 20MB and
+      $chacha_library and
+      2 of them
 }
 
 rule Arsenal237_Tor_C2_Infrastructure {
    meta:
-      description = "Detects Arsenal-237 enc_c2.exe Tor hidden service C2 domain and beacon endpoint strings"
+      description = "Detects Arsenal-237 enc_c2.exe Tor hidden service C2 — either by the specific onion address or by the /c2/beacon.php endpoint pattern in a PE context (avoids FP on generic Tor-aware binaries)"
       license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
       author = "The Hunters Ledger"
       reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
@@ -338,7 +341,12 @@ rule Arsenal237_Tor_C2_Infrastructure {
       $c2_protocol = "POST /c2/beacon.php" ascii
       $onion_tld = ".onion" ascii
    condition:
-      any of them
+      uint16(0) == 0x5A4D and
+      filesize < 20MB and
+      ($c2_domain or
+       ($c2_endpoint and $c2_protocol) or
+       ($c2_endpoint and $onion_tld) or
+       ($c2_protocol and $onion_tld))
 }
 
 rule Arsenal237_Ransomware_Operations {
@@ -381,7 +389,7 @@ rule Arsenal237_TEB_AntiDebug {
 
 rule Arsenal237_Rust_Compilation_Artifacts {
    meta:
-      description = "Detects Rust compiler and Cargo registry artifacts in Arsenal-237 malware binaries"
+      description = "Detects Rust compilation artifacts unique to Arsenal-237 build environment — /root/.cargo path indicates root-built (rare in legitimate Rust binaries) combined with index.crates.io presence"
       license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
       author = "The Hunters Ledger"
       reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
@@ -391,10 +399,13 @@ rule Arsenal237_Rust_Compilation_Artifacts {
    strings:
       $rust_lib_path = "/root/.cargo/registry/src/" ascii
       $crates_io = "index.crates.io" ascii
-      $rustc = "rustc" ascii
-      $rust_std = "std" ascii
+      $rustc_marker = "rustc-1." ascii
+      $cargo_marker = "/.cargo/registry/" ascii
    condition:
-      2 of them
+      uint16(0) == 0x5A4D and
+      filesize < 20MB and
+      $rust_lib_path and
+      1 of ($crates_io, $rustc_marker, $cargo_marker)
 }
 
 rule Arsenal237_RaaS_Builder_Tracking {
@@ -597,7 +608,7 @@ rule Arsenal237_ChaCha20_Key {
 
 rule Arsenal237_Campaign_Identifiers {
    meta:
-      description = "Detects Arsenal-237 new_enc.exe campaign ID, version string v0.5-beta, and RustRansomNoteTask scheduled task name"
+      description = "Detects Arsenal-237 new_enc.exe by campaign ID or RustRansomNoteTask scheduled-task name (version string alone is too generic to anchor)"
       license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
       author = "The Hunters Ledger"
       reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
@@ -608,9 +619,12 @@ rule Arsenal237_Campaign_Identifiers {
    strings:
       $campaign_id = "ICIIXGD1X8ZJ4T1MTQ6TLQIDJEMDE7U4" ascii wide
       $version = "v0.5-beta" ascii wide
-      $ransom_task = "RustRansomNoteTask" ascii wide
+      $ransom_task = "RustRansomNoteTask" ascii wide fullword
    condition:
-      any of them
+      uint16(0) == 0x5A4D and
+      filesize < 20MB and
+      ($campaign_id or $ransom_task or
+       ($version and ($campaign_id or $ransom_task)))
 }
 
 rule Arsenal237_Veritas_Backup_Targeting {

--- a/yara/mal_arsenal237_ransomware.yar
+++ b/yara/mal_arsenal237_ransomware.yar
@@ -36,8 +36,8 @@ rule Chromelevator_Browser_Credential_Extraction {
       $load_resource = "LoadResource" nocase ascii
    condition:
       ($filename and $payload and ($extraction or ($cookies and $passwords))) or
-      (3 of ($chrome, $brave, $edge) and 2 of ($extraction, $cookies, $passwords)) or
-      ($reflective and $named_pipe and any of ($chrome, $brave, $edge)) or
+      (3 of ($chrome, $brave, $edge) and 2 of ($extraction, $cookies, $passwords, $payments)) or
+      ($reflective and $named_pipe and any of ($chrome, $brave, $edge) and 2 of ($create_pipe, $connect_pipe, $find_resource, $load_resource)) or
       (2 of ($verbose, $fingerprint, $output) and any of ($chrome, $brave, $edge))
 }
 
@@ -77,7 +77,7 @@ rule Reflective_DLL_Injection_Framework {
       family = "Arsenal-237"
       id = "4a88262f-f5b3-568c-b25a-3f54412b4ffc"
    strings:
-      $dos_header = "MZ" at 0
+      $dos_header = "MZ"
       $reflective_loader = "ReflectiveLoader" nocase ascii
       $reflective_export = "reflective" nocase ascii wide
       $alloc = "VirtualAllocEx" nocase ascii
@@ -89,7 +89,7 @@ rule Reflective_DLL_Injection_Framework {
       $zw_protect = "ZwProtectVirtualMemory" nocase ascii
       $zw_create = "ZwCreateThreadEx" nocase ascii
    condition:
-      ($reflective_loader and $dos_header) or
+      (($reflective_loader or $reflective_export) and $dos_header at 0) or
       ($reflective_loader and all of ($zw_alloc, $zw_write, $zw_protect, $zw_create)) or
       ($reflective_loader and all of ($alloc, $write, $protect, $create_remote))
 }
@@ -167,7 +167,7 @@ rule Arsenal237_Rust_Compiled_Tools {
    condition:
       filesize > 900KB and filesize < 1MB and
       $chacha20_lib and $poly1305_lib and
-      $rust_constant
+      $rust_constant and $rust_error
 }
 
 rule Arsenal237_nethost_C2_Strings {
@@ -186,7 +186,7 @@ rule Arsenal237_nethost_C2_Strings {
       $rust_panic = "runtime error" ascii
       $winsock_init = "WSAStartup" ascii
    condition:
-      ($c2_targets or $env_discovery) and uint16(0) == 0x5A4D
+      ($c2_targets or ($env_discovery and $rust_panic and $winsock_init)) and uint16(0) == 0x5A4D
 }
 
 rule Arsenal237_nethost_PowerShell_Templates {
@@ -327,7 +327,7 @@ rule Arsenal237_TEB_AntiDebug {
       $sleep_loop = { 68 88 13 00 00 FF 15 }
       $sleep_1000 = { 68 E8 03 00 00 FF 15 }
    condition:
-      ($teb_api and ($sleep_loop or $sleep_1000))
+      ($teb_api and $stack_base and ($sleep_loop or $sleep_1000))
 }
 
 rule Arsenal237_Rust_Compilation_Artifacts {
@@ -486,12 +486,13 @@ rule Arsenal237_FullTestEnc_Comprehensive {
       $sysinfo = "/sysinfo-" ascii
       $lockbox = ".lockbox" ascii
       $netuse = "net use" ascii
+      $ransom_id = "Ransom ID" ascii
    condition:
       uint16(0) == 0x5A4D and
       filesize > 10MB and filesize < 20MB and
       $chacha and $rsa_lib and $ransom and
       (1 of ($rayon, $walkdir, $sysinfo)) and
-      ($lockbox or $netuse or "Ransom ID" ascii)
+      ($lockbox or $netuse or $ransom_id)
 }
 
 rule Arsenal237_ChaCha20_Key {

--- a/yara/mal_arsenal237_ransomware.yar
+++ b/yara/mal_arsenal237_ransomware.yar
@@ -94,25 +94,6 @@ rule Reflective_DLL_Injection_Framework {
       ($reflective_loader and all of ($alloc, $write, $protect, $create_remote))
 }
 
-rule Arsenal237_dec_fixed_FileHash {
-   meta:
-      description = "Detects Arsenal-237 dec_fixed.exe per-victim ransomware decryptor by exact cryptographic hash - recovery tool not an attack tool"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-dec_fixed-exe/"
-      date = "2026-01-26"
-      hash1 = "d73c4f127c5c0a7f9bf0f398e95dd55c7e8f6f6a5783c8cb314bd99c2d1c9802"
-      hash2 = "29014d4d6fc42219cd9cdc130b868382cf2c14c2"
-      hash3 = "7c5493a0a5df52682a5c2ba433634601"
-      family = "Arsenal-237"
-      malware_type = "Ransomware Decryptor"
-      id = "5b240e15-6f55-51b8-8f90-b3b14b9e9db8"
-   condition:
-      hash.sha256(0, filesize) == "d73c4f127c5c0a7f9bf0f398e95dd55c7e8f6f6a5783c8cb314bd99c2d1c9802" or
-      hash.md5(0, filesize) == "7c5493a0a5df52682a5c2ba433634601" or
-      hash.sha1(0, filesize) == "29014d4d6fc42219cd9cdc130b868382cf2c14c2"
-}
-
 rule Arsenal237_Victim_Key_Decryptor {
    meta:
       description = "Detects Arsenal-237 dec_fixed.exe victim-specific hardcoded ChaCha20 decryption key matching new_enc.exe encryption key"
@@ -189,25 +170,6 @@ rule Arsenal237_Rust_Compiled_Tools {
       $rust_constant
 }
 
-rule Arsenal237_nethost_FileHash {
-   meta:
-      description = "Detects Arsenal-237 nethost.dll C2 communication module by file hash - Rust DLL hijacking persistence targeting .NET host library"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-nethost-dll/"
-      date = "2026-01-26"
-      hash1 = "158f61b6d10ea2ce78769703a2ffbba9c08f0172e37013de960d9efe5e9fde14"
-      hash2 = "622ddbacaf769aef383435162a203489c08c8468"
-      hash3 = "f91ff1bb5699524524fff0e2587af040"
-      family = "Arsenal-237"
-      malware_type = "C2 Communication Module"
-      id = "f3063e07-ac28-5aac-8f6e-159e27d5944f"
-   condition:
-      hash.sha256(0, filesize) == "158f61b6d10ea2ce78769703a2ffbba9c08f0172e37013de960d9efe5e9fde14" or
-      hash.md5(0, filesize) == "f91ff1bb5699524524fff0e2587af040" or
-      hash.sha1(0, filesize) == "622ddbacaf769aef383435162a203489c08c8468"
-}
-
 rule Arsenal237_nethost_C2_Strings {
    meta:
       description = "Detects Arsenal-237 nethost.dll by hardcoded C2 target strings and environment variable discovery concatenation artifact"
@@ -282,25 +244,6 @@ rule Arsenal237_nethost_Rust_Indicators {
       $assertion_fail = "assertion `left  right` failed" ascii
    condition:
       2 of them and uint16(0) == 0x5A4D
-}
-
-rule Arsenal237_enc_c2_FileHash {
-   meta:
-      description = "Detects Arsenal-237 enc_c2.exe Rust-compiled ransomware by file hash - Tor C2 with ChaCha20 encryption"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-enc_c2-exe/"
-      date = "2026-01-26"
-      hash1 = "613d4d0f1612686742889e834ebc9ebff6ae021cf81a4c50f66369195ca01899"
-      hash2 = "34d3c75e79633eb3bf47e751fb31274760aeae09"
-      hash3 = "32a3497e57604e1037f1ff9993a8fdaa"
-      family = "Arsenal-237"
-      malware_type = "Ransomware"
-      id = "bd988044-c636-5d46-8fde-607527b38cde"
-   condition:
-      hash.sha256(0, filesize) == "613d4d0f1612686742889e834ebc9ebff6ae021cf81a4c50f66369195ca01899" or
-      hash.md5(0, filesize) == "32a3497e57604e1037f1ff9993a8fdaa" or
-      hash.sha1(0, filesize) == "34d3c75e79633eb3bf47e751fb31274760aeae09"
 }
 
 rule Arsenal237_ChaCha20_Encryption_Constants {
@@ -429,25 +372,6 @@ rule Arsenal237_RaaS_Builder_Tracking {
       ($builder_id_generic and $encryption_key and $victim_id and $machine_info))
 }
 
-rule Arsenal237_FullTestEnc_FileHash {
-   meta:
-      description = "Detects Arsenal-237 full_test_enc.exe by exact cryptographic hash - advanced Rust ransomware with ChaCha20+RSA and parallel encryption"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-full_test_enc-exe/"
-      date = "2026-01-27"
-      hash1 = "4d1fe7b54a0ce9ce2082c167b662ec138b890e3f305e67bdc13a5e9a24708518"
-      hash2 = "bc0788a36b6b839fc917be0577cd14e584c71fd8"
-      hash3 = "1fe8b9a14f9f8435c5fb5156bcbc174e"
-      family = "Arsenal-237"
-      malware_type = "Ransomware"
-      id = "80c95a71-ba72-500c-a52a-454d5780b2bc"
-   condition:
-      hash.sha256(0, filesize) == "4d1fe7b54a0ce9ce2082c167b662ec138b890e3f305e67bdc13a5e9a24708518" or
-      hash.md5(0, filesize) == "1fe8b9a14f9f8435c5fb5156bcbc174e" or
-      hash.sha1(0, filesize) == "bc0788a36b6b839fc917be0577cd14e584c71fd8"
-}
-
 rule Arsenal237_RustCrypto_ChaCha20_RSA {
    meta:
       description = "Detects Arsenal-237 full_test_enc.exe Rust ChaCha20 + RSA cryptographic library combination used for file encryption"
@@ -568,25 +492,6 @@ rule Arsenal237_FullTestEnc_Comprehensive {
       $chacha and $rsa_lib and $ransom and
       (1 of ($rayon, $walkdir, $sysinfo)) and
       ($lockbox or $netuse or "Ransom ID" ascii)
-}
-
-rule Arsenal237_new_enc_FileHash {
-   meta:
-      description = "Detects Arsenal-237 new_enc.exe Rust ransomware by exact file hash - human-operated ransomware with hardcoded ChaCha20 key"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/arsenal-237-new_enc-exe/"
-      date = "2026-01-26"
-      hash1 = "90d223b70448d68f7f48397df6a9e57de3a6b389d5d8dc0896be633ca95720f2"
-      hash2 = "2c01cefba27c4d3fcb3b450cb8e625e89bc54363"
-      hash3 = "a16ba61114fa5a40afce54459bbff21e"
-      family = "Arsenal-237"
-      malware_type = "Ransomware"
-      id = "d2228b50-9c6e-5242-8a21-ebc3bafbeac1"
-   condition:
-      hash.sha256(0, filesize) == "90d223b70448d68f7f48397df6a9e57de3a6b389d5d8dc0896be633ca95720f2" or
-      hash.md5(0, filesize) == "a16ba61114fa5a40afce54459bbff21e" or
-      hash.sha1(0, filesize) == "2c01cefba27c4d3fcb3b450cb8e625e89bc54363"
 }
 
 rule Arsenal237_ChaCha20_Key {


### PR DESCRIPTION
This PR adds detection coverage for **Arsenal-237**, a multi-component Rust-compiled ransomware suite observed in 2026, with no existing coverage in `signature-base`.

## Files added

| File | Rules | Coverage |
|---|---|---|
| `yara/mal_arsenal237_byovd_toolkit.yar` | 14 | BdApiUtil64.sys (weaponized Baidu antivirus driver), killer.dll (BYOVD framework with embedded vulnerable drivers), lpe.exe (5 privilege escalation techniques), rootkit.dll (Rust framework targeting 20+ security products) |
| `yara/mal_arsenal237_ransomware.yar` | 33 | enc_c2.exe / new_enc.exe / full_test_enc.exe (ChaCha20 + RSA encryptors), dec_fixed.exe (per-victim decryptor), nethost.dll (DLL-hijacking C2 module), chromelevator.exe (browser credential extraction) |

## Detection approach

Each component is covered by 1–7 rules combining:
- **Exact hash anchors** (SHA256/SHA1/MD5) for known samples
- **Behavioral / structural signatures** for variants — Rust crate path strings (\`/chacha20-0.9.1/\`, \`/rsa-0.9.9/\`, \`/rayon-1.11.0/\`, etc.), BYOVD service-creation patterns, Veritas/Veeam backup-process targeting, VSS deletion commands, Tor onion C2 endpoints, ChaCha20-Poly1305 cryptographic constants, RaaS builder ID tracking, SSDT bypass via KeServiceDescriptorTable resolution
- **PE structural checks** (\`uint16(0) == 0x5A4D\`, \`uint32(uint32(0x3C)) == 0x00004550\`) and **filesize bounds** to constrain FP risk

## Metadata

- \`author = "The Hunters Ledger"\` on every rule
- Per-rule \`license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"\` (preserves the original license rather than the default DRL 1.1; explicit license tag is supported per the repo README)
- Stable UUIDv5 \`id\` values (deterministic — regeneration yields the same IDs)
- \`family = "Arsenal-237"\` on every rule
- \`reference\` field pointing to the per-component technical writeup on the public site

## Source / context

Each rule's \`reference\` field links to the original technical analysis at [pixelatedcontinuum.github.io/Threat-Intel-Reports](https://pixelatedcontinuum.github.io/Threat-Intel-Reports/), where the full reverse-engineering and behavioral characterization for each component is documented. The rules were originally drafted as part of an analysis batch and are being contributed here for community distribution.

## Notes

- No rule-name collisions with existing \`signature-base\` content (checked against the master branch).
- The \`Arsenal237_Killer_DLL_BYOVD_Comprehensive\` and \`Arsenal237_Embedded_Vulnerable_Driver\` rules use \`#mz >= 2\` to count embedded PE headers; the \`\$mz = { 4D 5A }\` byte pattern is defined explicitly in both.
- Happy to split into smaller PRs, adjust rule naming, or address any false-positive feedback from triage.