### PR TITLE
Add RAT family detection: FleetAgent, XWorm, Pulsar, PoetRAT + Quasar/NjRAT and Remcos complements (30 rules)

### DIFF
--- a/iocs/hash-iocs.txt
+++ b/iocs/hash-iocs.txt
@@ -3376,3 +3376,8 @@ aea55e42c4436236278e5692d3dcbcbe5fe6ce0b;DAEMON Tools Lite supplychain compromis
 2d4eb55b01f59c62c6de9aacba9b47267d398fe4;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
 9dbfc23ebf36b3c0b56d2f93116abb32656c42e4;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
 295ce86226b933e7262c2ce4b36bdd6c389aaaef;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
+
+072ce701ec0252eeddd6a0501555296bce512a7b90422addbb6d3619ae10f4ff;FleetAgentFUD.exe WebSocket RAT payload
+9fc6b69623133f5d6f1f4cda0ec4319300080c9bbaa0f88c93f01eeba84e80e7;FleetAgentAdvanced dropped payload RuntimeOptimization.exe
+d9e91be0c1936ebaf1e93148e40dc7b4c4e2e6b3e4a47e7c85b5d4e7c5f2d9a1;XWorm RAT v5.x agent_xworm.exe
+f8e7e73bf2b26635800a042e7890a35f7376508f288a1ced3d3e12b173c5cb7e;XWorm RAT v2.4.0 agent_xworm_v2.exe

--- a/yara/rat_fleetagent.yar
+++ b/yara/rat_fleetagent.yar
@@ -6,24 +6,6 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
-rule FleetAgentFUD_FileHash_Exact {
-   meta:
-      description = "Detects FleetAgentFUD.exe by exact file hash - WebSocket RAT with FUD evasion and PowerShell execution policy bypass"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentfud-exe/"
-      date = "2026-01-12"
-      hash1 = "072ce701ec0252eeddd6a0501555296bce512a7b90422addbb6d3619ae10f4ff"
-      hash2 = "51aa8b08dc67cb91435ce58d4453a8ae5e0dd577"
-      hash3 = "5b37f5fc42384834b7aac5081a5bac85"
-      family = "FleetAgentFUD"
-      id = "7bbdc47c-1340-5b87-9b9c-5cecb6a03ce6"
-   condition:
-      uint16(0) == 0x5A4D and
-      filesize == 17920 and
-      hash.sha256(0, filesize) == "072ce701ec0252eeddd6a0501555296bce512a7b90422addbb6d3619ae10f4ff"
-}
-
 rule FleetAgentFUD_WebSocket_C2_Pattern {
    meta:
       description = "Detects FleetAgentFUD.exe WebSocket C2 implementation via protocol strings and message type indicators"
@@ -157,22 +139,6 @@ rule FleetAgentAdvanced_Dropper_Core {
       (any of ($api*) and any of ($persist*)) or
       hash.sha256(0, filesize) == "172258e53b9506a7671deab25d2ad360cd833a4942609f1a4836d305ffe4578b"
       )
-}
-
-rule FleetAgentAdvanced_RuntimeOptimization_Payload {
-   meta:
-      description = "Detects FleetAgentAdvanced.exe dropped payload RuntimeOptimization.exe by exact hash and file size"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentadvanced-exe/"
-      date = "2026-01-12"
-      hash1 = "9fc6b69623133f5d6f1f4cda0ec4319300080c9bbaa0f88c93f01eeba84e80e7"
-      family = "FleetAgentAdvanced"
-      id = "176719d7-fef3-5280-90e3-933830b5d0c5"
-   condition:
-      uint16(0) == 0x5A4D and
-      filesize == 27648 and
-      hash.sha256(0, filesize) == "9fc6b69623133f5d6f1f4cda0ec4319300080c9bbaa0f88c93f01eeba84e80e7"
 }
 
 rule FleetAgentAdvanced_Quad_Persistence_Pattern {

--- a/yara/rat_fleetagent.yar
+++ b/yara/rat_fleetagent.yar
@@ -1,0 +1,202 @@
+/*
+   Yara Rule Set
+   Identifier: FleetAgent RAT Family (FUD and Advanced variants)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule FleetAgentFUD_FileHash_Exact {
+   meta:
+      description = "Detects FleetAgentFUD.exe by exact file hash - WebSocket RAT with FUD evasion and PowerShell execution policy bypass"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentfud-exe/"
+      date = "2026-01-12"
+      hash1 = "072ce701ec0252eeddd6a0501555296bce512a7b90422addbb6d3619ae10f4ff"
+      hash2 = "51aa8b08dc67cb91435ce58d4453a8ae5e0dd577"
+      hash3 = "5b37f5fc42384834b7aac5081a5bac85"
+      family = "FleetAgentFUD"
+      id = "7bbdc47c-1340-5b87-9b9c-5cecb6a03ce6"
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize == 17920 and
+      hash.sha256(0, filesize) == "072ce701ec0252eeddd6a0501555296bce512a7b90422addbb6d3619ae10f4ff"
+}
+
+rule FleetAgentFUD_WebSocket_C2_Pattern {
+   meta:
+      description = "Detects FleetAgentFUD.exe WebSocket C2 implementation via protocol strings and message type indicators"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentfud-exe/"
+      date = "2026-01-12"
+      family = "FleetAgentFUD"
+      id = "b79dd451-00ab-5124-9384-ccf64b8fdc18"
+   strings:
+      $ws1 = "Connection: Upgrade" ascii wide
+      $ws2 = "Sec-WebSocket-Key: " ascii wide
+      $ws3 = "Sec-WebSocket-Version: 13" ascii wide
+      $ws4 = "X-Agent-Secret: " ascii wide
+      $msg1 = "\"type\":\"register\"" ascii wide nocase
+      $msg2 = "\"type\":\"heartbeat\"" ascii wide nocase
+      $msg3 = "machine_id" ascii wide
+      $msg4 = "hostname" ascii wide
+      $msg5 = "os_version" ascii wide
+      $msg6 = "agent_ver" ascii wide
+      $cmd1 = "cmd_type" ascii wide
+      $cmd2 = "command_id" ascii wide
+      $cmd3 = "powershell" ascii wide
+      $cmd4 = "sysinfo" ascii wide
+      $cmd5 = "clipboard" ascii wide
+      $api1 = "System.Net.Sockets" ascii
+      $api2 = "TcpClient" ascii
+      $api3 = "NetworkStream" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 50KB and
+      (
+      (3 of ($ws*) and 3 of ($msg*)) or
+      (2 of ($ws*) and 3 of ($cmd*)) or
+      (all of ($ws*) and any of ($api*))
+      )
+}
+
+rule FleetAgentFUD_PowerShell_Bypass {
+   meta:
+      description = "Detects FleetAgentFUD.exe PowerShell execution policy bypass string for clipboard theft and remote command execution"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentfud-exe/"
+      date = "2026-01-12"
+      family = "FleetAgentFUD"
+      id = "03b22454-8bce-562b-9c3b-019f9ae1b964"
+   strings:
+      $ps1 = "-NoP -NonI -W Hidden -Exec Bypass -C " ascii wide
+      $ps2 = "-NoProfile -NonInteractive -WindowStyle Hidden -ExecutionPolicy Bypass" ascii wide
+      $ps3 = "powershell" ascii wide nocase
+      $ps4 = "Get-Clipboard" ascii wide
+      $ps5 = "-Exec Bypass" ascii wide
+      $ps6 = "-ExecutionPolicy Bypass" ascii wide
+      $ps7 = "-W Hidden" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 100KB and
+      (
+      $ps1 or
+      $ps2 or
+      ($ps3 and ($ps5 or $ps6) and $ps7)
+      )
+}
+
+rule FleetAgent_Family_General {
+   meta:
+      description = "Detects FleetAgent malware family characteristics common to FUD and Advanced variants"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentfud-exe/"
+      date = "2026-01-12"
+      family = "FleetAgent"
+      id = "fafd5b4a-f551-5184-9fbc-e91c369bf3aa"
+   strings:
+      $name1 = "FleetAgent" ascii wide nocase
+      $name2 = "FleetAgentFUD" ascii wide
+      $name3 = "FleetAgentAdvanced" ascii wide
+      $name4 = "Microsoft.NET.Runtime" ascii wide
+      $ver1 = "agent_ver" ascii wide
+      $ver2 = "3.0.0" ascii wide
+      $cfg1 = "machine_id" ascii wide
+      $cfg2 = "hostname" ascii wide
+      $cfg3 = "agent_ver" ascii wide
+      $api1 = "VirtualProtect" ascii
+      $api2 = "ToBase64String" ascii
+      $api3 = "GetProcAddress" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      (
+      any of ($name*) or
+      (2 of ($cfg*) and any of ($ver*)) or
+      ($name4 and 2 of ($api*))
+      )
+}
+
+rule FleetAgentAdvanced_Dropper_Core {
+   meta:
+      description = "Detects FleetAgentAdvanced.exe dropper with quad-persistence architecture and .NET process injection targeting AppData"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentadvanced-exe/"
+      date = "2026-01-12"
+      hash1 = "172258e53b9506a7671deab25d2ad360cd833a4942609f1a4836d305ffe4578b"
+      family = "FleetAgentAdvanced"
+      id = "cc03bf1b-d12c-5616-94bd-67e037193ea3"
+   strings:
+      $func1 = "DropEmbeddedAgent" ascii wide
+      $func2 = "SetPersistence" ascii wide
+      $func3 = "CreateShortcut" ascii wide
+      $func4 = "StartWatchdog" ascii wide
+      $func5 = "RunWatchdog" ascii wide
+      $func6 = "InjectIntoProcess" ascii wide
+      $config1 = "EMBEDDED_AGENT" ascii wide
+      $config2 = "INSTALL_NAME" ascii wide
+      $config3 = "WATCHDOG_MUTEX" ascii wide
+      $config4 = "AGENT_SECRET" ascii wide
+      $persist1 = "RuntimeOptimization.exe" ascii wide
+      $persist2 = "Microsoft .NET Runtime Optimization" ascii wide
+      $persist3 = "Microsoft\\CLR" ascii wide
+      $api1 = "VirtualAllocEx" ascii
+      $api2 = "WriteProcessMemory" ascii
+      $api3 = "CreateRemoteThread" ascii
+      $api4 = "NtUnmapViewOfSection" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      (
+      3 of ($func*) or
+      (2 of ($config*) and any of ($persist*)) or
+      (any of ($api*) and any of ($persist*)) or
+      hash.sha256(0, filesize) == "172258e53b9506a7671deab25d2ad360cd833a4942609f1a4836d305ffe4578b"
+      )
+}
+
+rule FleetAgentAdvanced_RuntimeOptimization_Payload {
+   meta:
+      description = "Detects FleetAgentAdvanced.exe dropped payload RuntimeOptimization.exe by exact hash and file size"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentadvanced-exe/"
+      date = "2026-01-12"
+      hash1 = "9fc6b69623133f5d6f1f4cda0ec4319300080c9bbaa0f88c93f01eeba84e80e7"
+      family = "FleetAgentAdvanced"
+      id = "176719d7-fef3-5280-90e3-933830b5d0c5"
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize == 27648 and
+      hash.sha256(0, filesize) == "9fc6b69623133f5d6f1f4cda0ec4319300080c9bbaa0f88c93f01eeba84e80e7"
+}
+
+rule FleetAgentAdvanced_Quad_Persistence_Pattern {
+   meta:
+      description = "Detects .NET droppers with quad-persistence architecture: registry run key, startup LNK, scheduled task, and Microsoft masquerading"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/fleetagentadvanced-exe/"
+      date = "2026-01-12"
+      family = "FleetAgentAdvanced"
+      id = "7febd710-72a2-5cf3-b2fb-f693e25527c3"
+   strings:
+      $reg_run = "Software\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Run" ascii wide
+      $startup_folder = "\\\\Start Menu\\\\Programs\\\\Startup" ascii wide
+      $schtasks = "schtasks" ascii wide nocase
+      $lnk_file = ".lnk" ascii wide
+      $ms_mask1 = "Microsoft" ascii wide
+      $ms_mask2 = ".NET" ascii wide
+      $ms_mask3 = "Runtime" ascii wide
+      $ms_mask4 = "Optimization" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      for any i in (0..filesize-4): (uint32(i) == 0x424A5342) and
+      all of ($reg_run, $startup_folder, $schtasks, $lnk_file) and
+      3 of ($ms_mask*)
+}

--- a/yara/rat_fleetagent.yar
+++ b/yara/rat_fleetagent.yar
@@ -99,25 +99,24 @@ rule FleetAgent_Family_General {
       family = "FleetAgent"
       id = "fafd5b4a-f551-5184-9fbc-e91c369bf3aa"
    strings:
-      $name1 = "FleetAgent" ascii wide nocase
-      $name2 = "FleetAgentFUD" ascii wide
-      $name3 = "FleetAgentAdvanced" ascii wide
-      $name4 = "Microsoft.NET.Runtime" ascii wide
-      $ver1 = "agent_ver" ascii wide
+      $name1 = "FleetAgent" ascii wide fullword
+      $name2 = "FleetAgentFUD" ascii wide fullword
+      $name3 = "FleetAgentAdvanced" ascii wide fullword
+      $ms_masquerade = "Microsoft.NET.Runtime" ascii wide
+      $ver1 = "agent_ver" ascii wide fullword
       $ver2 = "3.0.0" ascii wide
-      $cfg1 = "machine_id" ascii wide
-      $cfg2 = "hostname" ascii wide
-      $cfg3 = "agent_ver" ascii wide
-      $api1 = "VirtualProtect" ascii
-      $api2 = "ToBase64String" ascii
-      $api3 = "GetProcAddress" ascii
+      $cfg1 = "machine_id" ascii wide fullword
+      $cfg2 = "hostname" ascii wide fullword
+      $api1 = "VirtualProtect" ascii fullword
+      $api2 = "ToBase64String" ascii fullword
+      $api3 = "GetProcAddress" ascii fullword
    condition:
       uint16(0) == 0x5A4D and
       filesize < 500KB and
       (
-      any of ($name*) or
-      (2 of ($cfg*) and any of ($ver*)) or
-      ($name4 and 2 of ($api*))
+         any of ($name1, $name2, $name3) or
+         ($ver1 and 2 of ($cfg*)) or
+         ($ms_masquerade and $ver1 and 2 of ($api*))
       )
 }
 

--- a/yara/rat_fleetagent.yar
+++ b/yara/rat_fleetagent.yar
@@ -6,6 +6,8 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
+import "hash"
+
 rule FleetAgentFUD_WebSocket_C2_Pattern {
    meta:
       description = "Detects FleetAgentFUD.exe WebSocket C2 implementation via protocol strings and message type indicators"
@@ -67,7 +69,8 @@ rule FleetAgentFUD_PowerShell_Bypass {
       (
       $ps1 or
       $ps2 or
-      ($ps3 and ($ps5 or $ps6) and $ps7)
+      ($ps3 and ($ps5 or $ps6) and $ps7) or
+      ($ps3 and $ps4 and ($ps5 or $ps6 or $ps7))
       )
 }
 
@@ -97,7 +100,7 @@ rule FleetAgent_Family_General {
       filesize < 500KB and
       (
          any of ($name1, $name2, $name3) or
-         ($ver1 and 2 of ($cfg*)) or
+         ($ver1 and $ver2 and 2 of ($cfg*)) or
          ($ms_masquerade and $ver1 and 2 of ($api*))
       )
 }

--- a/yara/rat_poetrat.yar
+++ b/yara/rat_poetrat.yar
@@ -1,0 +1,121 @@
+/*
+   Yara Rule Set
+   Identifier: PoetRAT (Golang RAT with Windows Defender masquerading)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule Agent_exe_PoetRAT_Comprehensive {
+   meta:
+      description = "Detects agent.exe PoetRAT Golang-compiled malware masquerading as Windows Defender with keylogging and encrypted C2"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-exe/"
+      date = "2026-01-12"
+      hash1 = "e7f9a29dde307afff4191dbc14a974405f287b10f359a39305dccdc0ee949385"
+      hash2 = "4e856041018242c62b3848d63b94c3763beda01648d3139060700c11e9334ad1"
+      family = "PoetRAT"
+      id = "6428c8b8-e1b8-57b4-a240-04836add976d"
+   strings:
+      $str_windefendersvc = "WinDefenderSvc.exe" ascii wide nocase
+      $str_defender_update = "WindowsDefenderUpdate" ascii wide nocase
+      $str_marker = ".wd_installed" ascii wide
+      $golang_runtime1 = "runtime.main" ascii
+      $golang_runtime2 = "runtime.goexit" ascii
+      $golang_runtime3 = "go.buildid" ascii
+      $golang_runtime4 = "runtime.morestack" ascii
+      $antidebug1 = "NtQueryInformationProcess" ascii wide
+      $antidebug2 = "SetConsoleCtrlHandler" ascii wide
+      $antidebug3 = "IsDebuggerPresent" ascii wide
+      $crypto1 = "crypto/aes" ascii
+      $crypto2 = "crypto/rsa" ascii
+      $crypto3 = "crypto/sha" ascii
+      $crypto4 = "chacha20" ascii nocase
+      $crypto5 = "golang.org/x/crypto" ascii
+      $net1 = "net.Listen" ascii
+      $net2 = "net.Dial" ascii
+      $net3 = "TCPConn" ascii
+      $net4 = "net/http" ascii
+      $reg1 = "Software\\Microsoft\\Windows\\CurrentVersion\\Run" ascii wide
+      $surv1 = "GetAsyncKeyState" ascii wide
+      $surv2 = "SetWindowsHookEx" ascii wide
+      $surv3 = "GetForegroundWindow" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      (
+      (2 of ($str_*)) and
+      (2 of ($golang_*)) and
+      (1 of ($antidebug*)) and
+      (1 of ($crypto*))
+      ) or
+      (
+      (3 of ($golang_*)) and
+      (2 of ($crypto*)) and
+      (1 of ($str_*)) and
+      (1 of ($net*)) and
+      (1 of ($surv*))
+      )
+      )
+}
+
+rule PoetRAT_Persistence_Component {
+   meta:
+      description = "Detects PoetRAT persistence components including WinDefenderSvc.exe masquerading and startup folder placement"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-exe/"
+      date = "2026-01-12"
+      hash1 = "4e856041018242c62b3848d63b94c3763beda01648d3139060700c11e9334ad1"
+      family = "PoetRAT"
+      id = "188018a9-6d37-5938-bfb2-5b3a63e1f029"
+   strings:
+      $defender_svc = "WinDefenderSvc.exe" ascii wide nocase
+      $defender_update = "WindowsDefenderUpdate" ascii wide nocase
+      $startup_path = "Start Menu\\Programs\\Startup" ascii wide nocase
+      $marker_file = ".wd_installed" ascii wide
+      $go1 = "Go build ID:" ascii
+      $go2 = "runtime.main" ascii
+      $go3 = "runtime.goexit" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      ($defender_svc and $defender_update) or
+      ($defender_svc and $startup_path) or
+      ($marker_file and any of ($go*))
+      )
+}
+
+rule Golang_RAT_Generic_Detection {
+   meta:
+      description = "Generic Golang-compiled RAT detection based on runtime artifacts, surveillance capabilities, and encrypted C2 communications"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-exe/"
+      date = "2026-01-12"
+      family = "GolangRAT"
+      id = "725f0479-29ac-5b18-8c00-bd2855008088"
+   strings:
+      $go_runtime1 = "runtime.main" ascii
+      $go_runtime2 = "runtime.goexit" ascii
+      $go_runtime3 = "runtime.morestack" ascii
+      $go_runtime4 = "go.buildid" ascii
+      $cap_keylog = "GetAsyncKeyState" ascii wide
+      $cap_keylog2 = "SetWindowsHookEx" ascii wide
+      $cap_rdp = "TermService" ascii wide nocase
+      $cap_ps = "powershell" ascii wide nocase
+      $cap_service = "CreateService" ascii wide
+      $crypto_aes = "crypto/aes" ascii
+      $crypto_tls = "crypto/tls" ascii
+      $crypto_modern = "chacha20" ascii nocase
+      $net_tcp = "net.Dial" ascii
+      $net_http = "net/http" ascii
+      $net_listen = "net.Listen" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      (2 of ($go_runtime*)) and
+      (2 of ($cap_*)) and
+      (1 of ($crypto_*)) and
+      (1 of ($net_*))
+}

--- a/yara/rat_poetrat.yar
+++ b/yara/rat_poetrat.yar
@@ -55,7 +55,8 @@ rule Agent_exe_PoetRAT_Comprehensive {
       (2 of ($crypto*)) and
       (1 of ($str_*)) and
       (1 of ($net*)) and
-      (1 of ($surv*))
+      (1 of ($surv*)) and
+      $reg1
       )
       )
 }

--- a/yara/rat_pulsar.yar
+++ b/yara/rat_pulsar.yar
@@ -1,0 +1,35 @@
+/*
+   Yara Rule Set
+   Identifier: Pulsar RAT (server.exe variant)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule Pulsar_RAT_Critical_Variant {
+   meta:
+      description = "Detects Pulsar RAT variant (server.exe) based on unique strings, HVNC capability, and BCrypt encryption"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/PULSAR-RAT/"
+      date = "2025-11-30"
+      hash1 = "2c4387ce18be279ea735ec4f0092698534921030aaa69949ae880e41a5c73766"
+      family = "PulsarRAT"
+      id = "bf130ee9-743d-553e-afb1-196820ed1471"
+   strings:
+      $pulsar = "Pulsar.Common" wide ascii
+      $hvnc = "HVNC" wide ascii
+      $keylog = "KeyLogger" wide ascii
+      $msgpack = "MessagePackSerializer" wide ascii
+      $bcrypt = "BCryptEncrypt" wide ascii
+      $winre = "Recovery\\OEM\\" wide ascii nocase
+      $runonce = "CurrentVersion\\RunOnce" wide ascii
+      $remote_desktop = "RemoteDesktop" wide ascii
+      $passwords = "Passwords" wide ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      uint32(uint32(0x3C)) == 0x00004550 and
+      filesize > 1MB and filesize < 2MB and
+      all of ($pulsar, $hvnc, $keylog, $msgpack, $bcrypt, $winre) and
+      2 of ($remote_desktop, $passwords)
+}

--- a/yara/rat_pulsar.yar
+++ b/yara/rat_pulsar.yar
@@ -30,6 +30,6 @@ rule Pulsar_RAT_Critical_Variant {
       uint16(0) == 0x5A4D and
       uint32(uint32(0x3C)) == 0x00004550 and
       filesize > 1MB and filesize < 2MB and
-      all of ($pulsar, $hvnc, $keylog, $msgpack, $bcrypt, $winre) and
+      all of ($pulsar, $hvnc, $keylog, $msgpack, $bcrypt, $winre, $runonce) and
       2 of ($remote_desktop, $passwords)
 }

--- a/yara/rat_quasar_njrat_dualrat.yar
+++ b/yara/rat_quasar_njrat_dualrat.yar
@@ -8,40 +8,40 @@
 
 rule Quasar_RAT_Core_Detection {
    meta:
-      description = "Detects Quasar RAT based on GUID, process injection, and surveillance strings including VM detection and C2 indicators"
+      description = "Detects Quasar RAT in the dual-RAT campaign by campaign C2 IP or multi-category behavioral indicators — requires multiple categories together to avoid FP on legitimate tools that use any one of these APIs (WriteProcessMemory, CreateRemoteThread, etc. are widely used)"
       license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
       author = "The Hunters Ledger"
       reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/dual-rat-analysis/"
       date = "2025-12-06"
-      hash1 = "2c4387ce18be279ea735ec4f0092698534921030aaa69949ae880e41a5c73766"
       family = "QuasarRAT"
       id = "e5642197-5e01-5aa7-ac85-5a645a92e85c"
    strings:
-      $inject1 = "inject_thread"
-      $inject2 = "WriteProcessMemory"
-      $inject3 = "CreateRemoteThread"
+      $inject1 = "inject_thread" fullword
+      $inject2 = "WriteProcessMemory" fullword
+      $inject3 = "CreateRemoteThread" fullword
       $vm_detect1 = "VirtualBox"
       $vm_detect2 = "VMware"
       $vm_detect3 = "QEMU"
       $debug_detect1 = "Debugger"
-      $debug_detect2 = "IsDebuggerPresent"
+      $debug_detect2 = "IsDebuggerPresent" fullword
       $c2_1 = "185.208.159.182"
       $c2_2 = "ipwho.is"
       $c2_3 = "api.ipify.org"
       $persist1 = "RuntimeBroker"
       $persist2 = "schtasks"
       $persist3 = "ONLOGON"
-      $surv1 = "keylogger"
-      $surv2 = "screenshot"
-      $surv3 = "webcam"
-      $surv4 = "clipboard"
+      $surv1 = "keylogger" fullword
+      $surv2 = "screenshot" fullword
+      $surv3 = "webcam" fullword
+      $surv4 = "clipboard" fullword
    condition:
       uint16(0) == 0x5A4D and
+      filesize < 5MB and
       (
-      any of ($inject*) or
-      (any of ($vm_detect*) and any of ($debug_detect*)) or
-      any of ($c2_*) or
-      (any of ($persist*) and any of ($surv*))
+         $c2_1 or
+         (2 of ($inject*) and 2 of ($surv*)) or
+         (all of ($vm_detect*) and any of ($debug_detect*) and 2 of ($surv*)) or
+         (2 of ($persist*) and 3 of ($surv*) and 1 of ($inject*))
       )
 }
 
@@ -65,7 +65,7 @@ rule Quasar_RAT_MarkOfWeb_Removal {
 
 rule NjRAT_XWorm_Core_Detection {
    meta:
-      description = "Detects NjRAT/XWorm based on VB.NET characteristics, Pastebin dead-drop C2, and critical process protection"
+      description = "Detects NjRAT/XWorm via NjRAT-specific config field names (the misspelled 'Groub' and 'USBNM' are NjRAT internal identifiers — high-confidence anchors) or Pastebin dead-drop C2 combined with config indicators. Avoids FPs on every VB.NET binary."
       license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
       author = "The Hunters Ledger"
       reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/dual-rat-analysis/"
@@ -76,36 +76,32 @@ rule NjRAT_XWorm_Core_Detection {
    strings:
       $vb_net1 = "Microsoft.VisualBasic"
       $vb_net2 = "System.Windows.Forms"
-      $config1 = "PasteUrl"
-      $config2 = "Groub"
-      $config3 = "USBNM"
-      $config4 = "InstallDir"
-      $config5 = "Mutex"
+      $config_specific1 = "Groub" fullword ascii wide
+      $config_specific2 = "USBNM" fullword ascii wide
+      $config_specific3 = "PasteUrl" fullword ascii wide
+      $config_generic1 = "InstallDir" fullword
+      $config_generic2 = "Mutex" fullword
       $pastebin1 = "pastebin.com"
       $pastebin2 = "raw/"
       $pastebin3 = "iPhone Safari"
-      $persist1 = "conhost"
+      $persist1 = "conhost" fullword
       $persist2 = "minute /mo 1"
       $persist3 = "Startup"
-      $persist4 = "Run"
-      $critical1 = "RtlSetProcessIsCritical"
+      $persist4 = "schtasks /create"
+      $critical1 = "RtlSetProcessIsCritical" fullword
       $critical2 = "BSOD"
-      $sleep1 = "SetThreadExecutionState"
-      $surv1 = "capCreateCaptureWindowA"
-      $surv2 = "webcam"
-      $surv3 = "microphone"
-      $surv4 = "keylogger"
+      $surv1 = "capCreateCaptureWindowA" fullword
+      $surv2 = "webcam" fullword
+      $surv3 = "microphone" fullword
+      $surv4 = "keylogger" fullword
    condition:
       uint16(0) == 0x5A4D and
-      filesize < 50000 and
+      filesize < 500KB and
       (
-      any of ($vb_net*) or
-      any of ($config*) or
-      any of ($pastebin*) or
-      any of ($persist*) or
-      any of ($critical*) or
-      any of ($sleep*) or
-      any of ($surv*)
+         hash.sha256(0, filesize) == "950aadba6993619858294599b3458d5d2221f10fe72b3db3e49883d496a705bb" or
+         1 of ($config_specific*) or
+         (any of ($pastebin*) and 2 of ($config_generic*, $persist*, $critical*)) or
+         ($critical1 and 2 of ($surv*) and 1 of ($persist*))
       )
 }
 

--- a/yara/rat_quasar_njrat_dualrat.yar
+++ b/yara/rat_quasar_njrat_dualrat.yar
@@ -6,6 +6,8 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
+import "hash"
+
 rule Quasar_RAT_Core_Detection {
    meta:
       description = "Detects Quasar RAT in the dual-RAT campaign by campaign C2 IP or multi-category behavioral indicators — requires multiple categories together to avoid FP on legitimate tools that use any one of these APIs (WriteProcessMemory, CreateRemoteThread, etc. are widely used)"
@@ -41,7 +43,8 @@ rule Quasar_RAT_Core_Detection {
          $c2_1 or
          (2 of ($inject*) and 2 of ($surv*)) or
          (all of ($vm_detect*) and any of ($debug_detect*) and 2 of ($surv*)) or
-         (2 of ($persist*) and 3 of ($surv*) and 1 of ($inject*))
+         (2 of ($persist*) and 3 of ($surv*) and 1 of ($inject*)) or
+         (1 of ($c2_2, $c2_3) and 2 of ($persist*) and 1 of ($surv*))
       )
 }
 
@@ -100,7 +103,7 @@ rule NjRAT_XWorm_Core_Detection {
       (
          hash.sha256(0, filesize) == "950aadba6993619858294599b3458d5d2221f10fe72b3db3e49883d496a705bb" or
          1 of ($config_specific*) or
-         (any of ($pastebin*) and 2 of ($config_generic*, $persist*, $critical*)) or
+         (any of ($pastebin*) and 1 of ($vb_net*) and 2 of ($config_generic*, $persist*, $critical*)) or
          ($critical1 and 2 of ($surv*) and 1 of ($persist*))
       )
 }

--- a/yara/rat_quasar_njrat_dualrat.yar
+++ b/yara/rat_quasar_njrat_dualrat.yar
@@ -1,0 +1,130 @@
+/*
+   Yara Rule Set
+   Identifier: Dual-RAT Campaign (Quasar + NjRAT/XWorm)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule Quasar_RAT_Core_Detection {
+   meta:
+      description = "Detects Quasar RAT based on GUID, process injection, and surveillance strings including VM detection and C2 indicators"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/dual-rat-analysis/"
+      date = "2025-12-06"
+      hash1 = "2c4387ce18be279ea735ec4f0092698534921030aaa69949ae880e41a5c73766"
+      family = "QuasarRAT"
+      id = "e5642197-5e01-5aa7-ac85-5a645a92e85c"
+   strings:
+      $inject1 = "inject_thread"
+      $inject2 = "WriteProcessMemory"
+      $inject3 = "CreateRemoteThread"
+      $vm_detect1 = "VirtualBox"
+      $vm_detect2 = "VMware"
+      $vm_detect3 = "QEMU"
+      $debug_detect1 = "Debugger"
+      $debug_detect2 = "IsDebuggerPresent"
+      $c2_1 = "185.208.159.182"
+      $c2_2 = "ipwho.is"
+      $c2_3 = "api.ipify.org"
+      $persist1 = "RuntimeBroker"
+      $persist2 = "schtasks"
+      $persist3 = "ONLOGON"
+      $surv1 = "keylogger"
+      $surv2 = "screenshot"
+      $surv3 = "webcam"
+      $surv4 = "clipboard"
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      any of ($inject*) or
+      (any of ($vm_detect*) and any of ($debug_detect*)) or
+      any of ($c2_*) or
+      (any of ($persist*) and any of ($surv*))
+      )
+}
+
+rule Quasar_RAT_MarkOfWeb_Removal {
+   meta:
+      description = "Detects Quasar RAT Zone.Identifier stream removal for anti-forensic indicator removal"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/dual-rat-analysis/"
+      date = "2025-12-06"
+      hash1 = "2c4387ce18be279ea735ec4f0092698534921030aaa69949ae880e41a5c73766"
+      family = "QuasarRAT"
+      id = "a2e913d8-0983-5d36-8bba-d9ddde38b68f"
+   strings:
+      $zone_stream = ":Zone.Identifier"
+      $delete_api = "DeleteFile"
+   condition:
+      uint16(0) == 0x5A4D and
+      all of them
+}
+
+rule NjRAT_XWorm_Core_Detection {
+   meta:
+      description = "Detects NjRAT/XWorm based on VB.NET characteristics, Pastebin dead-drop C2, and critical process protection"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/dual-rat-analysis/"
+      date = "2025-12-06"
+      hash1 = "950aadba6993619858294599b3458d5d2221f10fe72b3db3e49883d496a705bb"
+      family = "NjRAT"
+      id = "86a672cb-1ac0-5927-aeee-b8c0a19ce9a7"
+   strings:
+      $vb_net1 = "Microsoft.VisualBasic"
+      $vb_net2 = "System.Windows.Forms"
+      $config1 = "PasteUrl"
+      $config2 = "Groub"
+      $config3 = "USBNM"
+      $config4 = "InstallDir"
+      $config5 = "Mutex"
+      $pastebin1 = "pastebin.com"
+      $pastebin2 = "raw/"
+      $pastebin3 = "iPhone Safari"
+      $persist1 = "conhost"
+      $persist2 = "minute /mo 1"
+      $persist3 = "Startup"
+      $persist4 = "Run"
+      $critical1 = "RtlSetProcessIsCritical"
+      $critical2 = "BSOD"
+      $sleep1 = "SetThreadExecutionState"
+      $surv1 = "capCreateCaptureWindowA"
+      $surv2 = "webcam"
+      $surv3 = "microphone"
+      $surv4 = "keylogger"
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 50000 and
+      (
+      any of ($vb_net*) or
+      any of ($config*) or
+      any of ($pastebin*) or
+      any of ($persist*) or
+      any of ($critical*) or
+      any of ($sleep*) or
+      any of ($surv*)
+      )
+}
+
+rule NjRAT_XWorm_Triple_Persistence {
+   meta:
+      description = "Detects NjRAT/XWorm triple persistence mechanism via conhost-named scheduled task, run key, and startup LNK"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/dual-rat-analysis/"
+      date = "2025-12-06"
+      family = "NjRAT"
+      id = "85fbe6d2-865b-5f69-81dd-f0db8bf50511"
+   strings:
+      $task_name = "conhost"
+      $task_freq = "minute /mo 1"
+      $reg_key = "Software\\Microsoft\\Windows\\CurrentVersion\\Run"
+      $startup = "Startup\\conhost.lnk"
+      $schtasks = "schtasks /create"
+   condition:
+      uint16(0) == 0x5A4D and
+      all of them
+}

--- a/yara/rat_remcos_opendir.yar
+++ b/yara/rat_remcos_opendir.yar
@@ -1,0 +1,207 @@
+/*
+   Yara Rule Set
+   Identifier: Remcos RAT (OpenDirectory 203.159.90.147 campaign)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule Remcos_RAT_Family_Detection {
+   meta:
+      description = "Detects Remcos RAT based on mutex, strings, keylogging, and structural patterns - high confidence family rule"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/remcos-opendirectory-campaign/"
+      date = "2026-02-04"
+      malware_family = "Remcos"
+      id = "32642d64-41b4-5b64-801e-c295f9bfe4a9"
+   strings:
+      $mutex = "Remcos_Mutex_Inj" ascii wide
+      $banner = " * REMCOS v" ascii
+      $developer = "Breaking-Security.Net" ascii
+      $c2_1 = "Connected to C&C!" ascii
+      $c2_2 = "[KeepAlive]" ascii
+      $c2_3 = "[DataStart]" ascii
+      $keylog_1 = "onlinelogs" ascii
+      $keylog_2 = "offlinelogs" ascii
+      $keylog_3 = " [Ctrl + V]" ascii
+      $keylog_4 = "[Following text has been copied to clipboard:]" ascii
+      $keylog_5 = "[Following text has been pasted from clipboard:]" ascii
+      $cred_1 = "[Chrome StoredLogins found, cleared!]" ascii
+      $cred_2 = "[Firefox StoredLogins cleared!]" ascii
+      $cred_3 = "[Chrome Cookies found, cleared!]" ascii
+      $persist_1 = "Userinit" ascii
+      $persist_2 = "install.bat" ascii
+      $persist_3 = "EnableLUA" ascii
+      $cmd_1 = "consolecmd" ascii
+      $cmd_2 = "remscriptexecd" ascii
+      $cmd_3 = "getproclist" ascii
+      $api_inject_1 = "VirtualAllocEx" ascii
+      $api_inject_2 = "WriteProcessMemory" ascii
+      $api_screen = "GdipSaveImageToStream" ascii
+      $api_audio = "waveInOpen" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 5MB and
+      (
+      $mutex or
+      ($banner and $developer) or
+      (3 of ($c2_*)) or
+      (2 of ($keylog_*) and 2 of ($api_*)) or
+      (2 of ($cred_*)) or
+      (8 of them)
+      )
+}
+
+rule Remcos_VB6_Dropper_Obfuscated {
+   meta:
+      description = "Detects VB6 droppers delivering Remcos RAT with obfuscated strings and anti-analysis techniques"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/remcos-opendirectory-campaign/"
+      date = "2026-02-04"
+      malware_family = "Remcos"
+      id = "2456c4bc-9d08-5402-ab59-0b853c9def47"
+   strings:
+      $vb6_runtime = "MSVBVM60.DLL" ascii nocase
+      $vb6_func_1 = "rtcCreateObject2" ascii
+      $vb6_func_2 = "DllFunctionCall" ascii
+      $vb6_func_3 = "rtcShell" ascii
+      $fso = "Scripting.FileSystemObject" wide
+      $dropped_name = "0.dll" wide ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      $vb6_runtime and
+      (
+      (2 of ($vb6_func_*) and $fso and $dropped_name) or
+      (3 of ($vb6_func_*) and ($fso or $dropped_name))
+      )
+}
+
+rule Remcos_UAC_Bypass_Persistence {
+   meta:
+      description = "Detects Remcos RAT UAC bypass via EnableLUA registry modification and multi-vector persistence mechanisms"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/remcos-opendirectory-campaign/"
+      date = "2026-02-04"
+      malware_family = "Remcos"
+      id = "e53a05eb-deea-575f-bb7d-2a97e8d63bf0"
+   strings:
+      $uac_cmd_1 = "reg.exe ADD HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\System /v EnableLUA" ascii wide
+      $uac_cmd_2 = "EnableLUA /t REG_DWORD /d 0 /f" ascii wide
+      $persist_1 = "Software\\Microsoft\\Windows\\CurrentVersion\\Run" ascii wide
+      $persist_2 = "Software\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon\\Userinit" ascii wide
+      $persist_3 = "Software\\Microsoft\\Windows\\CurrentVersion\\Policies\\Explorer\\Run" ascii wide
+      $install_path = "AppData\\Roaming\\remcos\\remcos.exe" ascii wide
+      $melt_1 = "PING 127.0.0.1 -n 2" ascii wide
+      $melt_3 = "install.bat" ascii wide
+      $remcos_mutex = "Remcos_Mutex_Inj" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      (any of ($uac_cmd_*) and $install_path) or
+      (3 of ($persist_*) and $install_path) or
+      ($persist_2 and $install_path and $remcos_mutex) or
+      ($remcos_mutex and 2 of ($persist_*) and any of ($uac_cmd_*))
+      )
+}
+
+rule Remcos_Process_Injection_Module {
+   meta:
+      description = "Detects Remcos RAT process injection capabilities targeting explorer.exe and msedge.exe for code execution"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/remcos-opendirectory-campaign/"
+      date = "2026-02-04"
+      malware_family = "Remcos"
+      id = "7b63db4d-16d8-5fd6-a578-7f908e409c25"
+   strings:
+      $api_1 = "VirtualAllocEx" ascii
+      $api_2 = "WriteProcessMemory" ascii
+      $api_3 = "CreateRemoteThread" ascii
+      $api_4 = "GetThreadContext" ascii
+      $api_5 = "SetThreadContext" ascii
+      $api_6 = "ResumeThread" ascii
+      $target_1 = "explorer.exe" ascii wide
+      $target_2 = "msedge.exe" ascii wide
+      $desktop_ini = "desktop.ini" ascii wide
+      $remcos_mutex = "Remcos_Mutex_Inj" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      (5 of ($api_*) and 2 of ($target_*)) or
+      ($remcos_mutex and 4 of ($api_*)) or
+      ($desktop_ini and 4 of ($api_*) and $target_1)
+      )
+}
+
+rule Remcos_Surveillance_Module {
+   meta:
+      description = "Detects Remcos RAT surveillance capabilities including keylogging, screen capture, audio recording, and clipboard monitoring"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/remcos-opendirectory-campaign/"
+      date = "2026-02-04"
+      malware_family = "Remcos"
+      id = "035c58b2-9e13-5f85-af94-dc4cdc0dc9c8"
+   strings:
+      $keylog_api_1 = "SetWindowsHookExA" ascii
+      $screen_api_1 = "GdipSaveImageToStream" ascii
+      $screen_api_2 = "BitBlt" ascii
+      $audio_api_1 = "waveInOpen" ascii
+      $audio_api_2 = "waveInAddBuffer" ascii
+      $clip_api_1 = "GetClipboardData" ascii
+      $surv_str_1 = "onlinelogs" ascii
+      $surv_str_2 = "offlinelogs" ascii
+      $surv_str_3 = "[Ctrl + V]" ascii
+      $activity_1 = "GetLastInputInfo" ascii
+   condition:
+      uint16(0) == 0x5A4D and
+      (
+      (any of ($keylog_api_*) and any of ($screen_api_*) and any of ($audio_api_*)) or
+      (any of ($keylog_api_*) and any of ($clip_api_*) and 2 of ($surv_str_*)) or
+      (3 of ($surv_str_*) and $activity_1)
+      )
+}
+
+rule Remcos_OpenDirectory_Campaign_203_159_90_147 {
+   meta:
+      description = "Detects specific Remcos RAT samples from OpenDirectory 203.159.90.147 campaign with campaign-specific installation paths"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/remcos-opendirectory-campaign/"
+      date = "2026-02-04"
+      hash1 = "04693af3b0a7c9788daba8e35f429ba6"
+      hash2 = "3d7b442573acf64c3aad17b23d224dc9"
+      malware_family = "Remcos"
+      campaign = "OpenDirectory 203.159.90.147"
+      id = "fbab3433-10b2-59cb-9fef-4739b65ebc88"
+   strings:
+      $mutex = "Remcos_Mutex_Inj" ascii wide
+      $window_class = "MsgWindowClass" ascii
+      $uac_cmd = "EnableLUA /t REG_DWORD /d 0 /f" ascii wide
+      $chrome_path = "\\AppData\\Local\\Google\\Chrome\\User Data\\Default\\Login Data" ascii wide
+      $firefox_path = "\\AppData\\Roaming\\Mozilla\\Firefox\\Profiles\\" ascii wide
+      $install_path = "\\AppData\\Roaming\\remcos\\remcos.exe" ascii wide
+      $temp_dll = "\\Temp\\0.dll" ascii wide
+      $install_bat = "install.bat" ascii wide
+      $ping_delay = "PING 127.0.0.1 -n 2" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 2MB and
+      (
+      hash.md5(0, filesize) == "04693af3b0a7c9788daba8e35f429ba6" or
+      hash.md5(0, filesize) == "3d7b442573acf64c3aad17b23d224dc9" or
+      (
+      $mutex and
+      (
+      $uac_cmd or
+      ($chrome_path and $firefox_path) or
+      ($install_path and $temp_dll) or
+      ($install_bat and $ping_delay)
+      )
+      )
+      )
+}

--- a/yara/rat_remcos_opendir.yar
+++ b/yara/rat_remcos_opendir.yar
@@ -6,6 +6,8 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
+import "hash"
+
 rule Remcos_RAT_Family_Detection {
    meta:
       description = "Detects Remcos RAT based on mutex, strings, keylogging, and structural patterns - high confidence family rule"
@@ -104,7 +106,8 @@ rule Remcos_UAC_Bypass_Persistence {
       (any of ($uac_cmd_*) and $install_path) or
       (3 of ($persist_*) and $install_path) or
       ($persist_2 and $install_path and $remcos_mutex) or
-      ($remcos_mutex and 2 of ($persist_*) and any of ($uac_cmd_*))
+      ($remcos_mutex and 2 of ($persist_*) and any of ($uac_cmd_*)) or
+      ($remcos_mutex and $melt_1 and $melt_3)
       )
 }
 
@@ -197,6 +200,7 @@ rule Remcos_OpenDirectory_Campaign_203_159_90_147 {
       (
       $mutex and
       (
+      $window_class or
       $uac_cmd or
       ($chrome_path and $firefox_path) or
       ($install_path and $temp_dll) or

--- a/yara/rat_remcos_opendir.yar
+++ b/yara/rat_remcos_opendir.yar
@@ -192,8 +192,8 @@ rule Remcos_OpenDirectory_Campaign_203_159_90_147 {
       uint16(0) == 0x5A4D and
       filesize < 2MB and
       (
-      hash.md5(0, filesize) == "04693af3b0a7c9788daba8e35f429ba6" or
-      hash.md5(0, filesize) == "3d7b442573acf64c3aad17b23d224dc9" or
+      hash.sha256(0, filesize) == "ebdd31a7622288b15439396a5758ffb0133d28b4bb11e9386187661a4b7d5f82" or
+      hash.sha256(0, filesize) == "db218dd5f53fbcf39a6db043c8455667c3dbef44abe14865e8b962b4c676372e" or
       (
       $mutex and
       (

--- a/yara/rat_xworm.yar
+++ b/yara/rat_xworm.yar
@@ -42,7 +42,8 @@ rule XWorm_V5_Core_Detection {
       (
       2 of ($dotnet_ws, $dotnet_crypto, $dotnet_diag) and
       3 of ($send_async, $recv_async, $websocket_state, $heartbeat, $reconnect) and
-      1 of ($hide_window, $get_console)
+      1 of ($hide_window, $get_console) and
+      1 of ($b64, $md5_hash)
       )
 }
 
@@ -70,7 +71,7 @@ rule XWorm_V5_Persistence_Mechanisms {
       filesize < 500KB and
       2 of ($schtask, $reg_run, $startup) and
       ($appdata or $copy_self) and
-      ($ps_bypass or $execution_pol)
+      ($ps_bypass or ($execution_pol and $bypass))
 }
 
 rule XWorm_V5_Surveillance_Capabilities {
@@ -152,7 +153,6 @@ rule XWorm_PowerShell_Recon {
    condition:
       uint16(0) == 0x5A4D and
       3 of them
-      }
 }
 
 rule XWorm_AgentSec_Authentication {

--- a/yara/rat_xworm.yar
+++ b/yara/rat_xworm.yar
@@ -6,21 +6,6 @@
    License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
 */
 
-rule XWorm_V5_FileHash {
-   meta:
-      description = "Detects agent_xworm.exe XWorm RAT v5.x by file hash - .NET RAT with WebSocket C2 and multi-stage persistence"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-exe/"
-      date = "2026-01-12"
-      hash1 = "d9e91be0c1936ebaf1e93148e40dc7b4c4e2e6b3e4a47e7c85b5d4e7c5f2d9a1"
-      family = "XWorm"
-      malware_type = "RAT"
-      id = "0d46751f-6750-56b2-9fe7-776abe795537"
-   condition:
-      hash.sha256(0, filesize) == "d9e91be0c1936ebaf1e93148e40dc7b4c4e2e6b3e4a47e7c85b5d4e7c5f2d9a1"
-}
-
 rule XWorm_V5_Core_Detection {
    meta:
       description = "Detects XWorm RAT v5.x based on .NET framework imports, WebSocket C2 communication pattern, and multi-stage persistence mechanisms"
@@ -110,25 +95,6 @@ rule XWorm_V5_Surveillance_Capabilities {
       uint16(0) == 0x5A4D and
       filesize < 500KB and
       3 of them
-}
-
-rule XWorm_V2_Specific_Hash {
-   meta:
-      description = "Detects agent_xworm_v2.exe XWorm RAT v2.4.0 by file hash - WebSocket C2 to 109.230.231.37 with AgentSec authentication"
-      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
-      author = "The Hunters Ledger"
-      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-v2-exe/"
-      date = "2026-01-12"
-      hash1 = "f8e7e73bf2b26635800a042e7890a35f7376508f288a1ced3d3e12b173c5cb7e"
-      hash2 = "7c624e0b11c817d516f9411972191c4627fd2e53"
-      hash3 = "4164a1945d8373255a5cb7e42f05c259"
-      family = "XWorm"
-      malware_type = "RAT"
-      id = "8550258f-5635-51a0-8c5b-6c2fb5bd767c"
-   condition:
-      hash.sha256(0, filesize) == "f8e7e73bf2b26635800a042e7890a35f7376508f288a1ced3d3e12b173c5cb7e" or
-      hash.md5(0, filesize) == "4164a1945d8373255a5cb7e42f05c259" or
-      hash.sha1(0, filesize) == "7c624e0b11c817d516f9411972191c4627fd2e53"
 }
 
 rule XWorm_RAT_V2_Family {

--- a/yara/rat_xworm.yar
+++ b/yara/rat_xworm.yar
@@ -1,0 +1,234 @@
+/*
+   Yara Rule Set
+   Identifier: XWorm RAT (v2.x and v5.x variants)
+   Author: The Hunters Ledger
+   Source: https://pixelatedcontinuum.github.io/Threat-Intel-Reports/
+   License: CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/
+*/
+
+rule XWorm_V5_FileHash {
+   meta:
+      description = "Detects agent_xworm.exe XWorm RAT v5.x by file hash - .NET RAT with WebSocket C2 and multi-stage persistence"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-exe/"
+      date = "2026-01-12"
+      hash1 = "d9e91be0c1936ebaf1e93148e40dc7b4c4e2e6b3e4a47e7c85b5d4e7c5f2d9a1"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "0d46751f-6750-56b2-9fe7-776abe795537"
+   condition:
+      hash.sha256(0, filesize) == "d9e91be0c1936ebaf1e93148e40dc7b4c4e2e6b3e4a47e7c85b5d4e7c5f2d9a1"
+}
+
+rule XWorm_V5_Core_Detection {
+   meta:
+      description = "Detects XWorm RAT v5.x based on .NET framework imports, WebSocket C2 communication pattern, and multi-stage persistence mechanisms"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "0dd2b93b-5092-584a-8c56-905d92241f68"
+   strings:
+      $dotnet_ws = "System.Net.WebSockets" ascii wide
+      $dotnet_crypto = "System.Security.Cryptography" ascii wide
+      $dotnet_diag = "System.Diagnostics.Process" ascii wide
+      $mscorlib = "mscorlib" ascii wide
+      $xworm_mutex = "XWorm_Mutex" ascii wide nocase
+      $xworm_version = "XWorm" ascii wide
+      $heartbeat = "Heartbeat" ascii wide nocase
+      $reconnect = "Reconnect" ascii wide nocase
+      $send_async = "SendAsync" ascii wide
+      $recv_async = "ReceiveAsync" ascii wide
+      $websocket_state = "WebSocketState" ascii wide
+      $hide_window = "ShowWindow" ascii wide
+      $get_console = "GetConsoleWindow" ascii wide
+      $b64 = "ToBase64String" ascii wide
+      $md5_hash = "ComputeHash" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      $mscorlib and
+      (
+      ($xworm_mutex or $xworm_version) and $dotnet_ws and $heartbeat
+      ) or
+      (
+      2 of ($dotnet_ws, $dotnet_crypto, $dotnet_diag) and
+      3 of ($send_async, $recv_async, $websocket_state, $heartbeat, $reconnect) and
+      1 of ($hide_window, $get_console)
+      )
+}
+
+rule XWorm_V5_Persistence_Mechanisms {
+   meta:
+      description = "Detects XWorm RAT v5.x multi-stage persistence using scheduled tasks, registry run keys, and startup folder mechanisms"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "92a47e83-5b7b-5de7-a7b0-a3b382c11e43"
+   strings:
+      $schtask = "schtasks" ascii wide nocase
+      $reg_run = "SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run" ascii wide nocase
+      $startup = "\\Microsoft\\Windows\\Start Menu\\Programs\\Startup" ascii wide nocase
+      $copy_self = "CopyFile" ascii wide
+      $appdata = "\\AppData\\Roaming\\" ascii wide nocase
+      $ps_bypass = "powershell" ascii wide nocase
+      $execution_pol = "ExecutionPolicy" ascii wide nocase
+      $bypass = "Bypass" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      2 of ($schtask, $reg_run, $startup) and
+      ($appdata or $copy_self) and
+      ($ps_bypass or $execution_pol)
+}
+
+rule XWorm_V5_Surveillance_Capabilities {
+   meta:
+      description = "Detects XWorm RAT v5.x surveillance capabilities including keylogging, clipboard monitoring, screenshot capture, and audio recording"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "aa62a397-84de-5365-b2b0-7af36892f71a"
+   strings:
+      $keylog = "GetAsyncKeyState" ascii wide
+      $clipboard = "GetClipboardData" ascii wide
+      $screenshot = "BitBlt" ascii wide
+      $audio = "waveInOpen" ascii wide
+      $webcam = "VideoCapture" ascii wide nocase
+      $desktop = "GetDesktopWindow" ascii wide
+      $screen_dc = "GetDC" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      3 of them
+}
+
+rule XWorm_V2_Specific_Hash {
+   meta:
+      description = "Detects agent_xworm_v2.exe XWorm RAT v2.4.0 by file hash - WebSocket C2 to 109.230.231.37 with AgentSec authentication"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-v2-exe/"
+      date = "2026-01-12"
+      hash1 = "f8e7e73bf2b26635800a042e7890a35f7376508f288a1ced3d3e12b173c5cb7e"
+      hash2 = "7c624e0b11c817d516f9411972191c4627fd2e53"
+      hash3 = "4164a1945d8373255a5cb7e42f05c259"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "8550258f-5635-51a0-8c5b-6c2fb5bd767c"
+   condition:
+      hash.sha256(0, filesize) == "f8e7e73bf2b26635800a042e7890a35f7376508f288a1ced3d3e12b173c5cb7e" or
+      hash.md5(0, filesize) == "4164a1945d8373255a5cb7e42f05c259" or
+      hash.sha1(0, filesize) == "7c624e0b11c817d516f9411972191c4627fd2e53"
+}
+
+rule XWorm_RAT_V2_Family {
+   meta:
+      description = "Detects XWorm RAT v2.x family based on .NET WebSocket C2, AgentSec authentication secret pattern, and MD5 fingerprinting"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-v2-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "562e9937-a646-53b9-8ea2-650ff3b5bdc0"
+   strings:
+      $dotnet1 = "System.Net.WebSockets" ascii wide
+      $dotnet2 = "System.Diagnostics.Process" ascii wide
+      $dotnet3 = "System.Security.Cryptography" ascii wide
+      $dotnet4 = "mscorlib" ascii wide
+      $version_pattern = /2\.[0-9]\.[0-9]/ ascii wide
+      $websocket = "WebSocket" ascii wide nocase
+      $agent_sec = "AgentSec_" ascii wide
+      $ps1 = "Get-Process" ascii wide nocase
+      $ps2 = "Get-Service" ascii wide nocase
+      $ps3 = "Win32_ComputerSystem" ascii wide
+      $stealth1 = "ShowWindow" ascii wide
+      $stealth2 = "GetConsoleWindow" ascii wide
+      $encode = "ToBase64String" ascii wide
+      $md5 = "MD5" ascii wide
+      $hash_compute = "ComputeHash" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 500KB and
+      (
+      ($dotnet1 and $websocket and $agent_sec and $version_pattern) or
+      (2 of ($dotnet1, $dotnet2, $dotnet3, $dotnet4) and 2 of ($ps1, $ps2, $ps3) and 1 of ($stealth1, $stealth2) and $encode) or
+      ($md5 and $hash_compute and $websocket and 1 of ($ps1, $ps2, $ps3))
+      )
+}
+
+rule XWorm_PowerShell_Recon {
+   meta:
+      description = "Detects XWorm v2.x embedded PowerShell reconnaissance command templates targeting process, service, and system information"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-v2-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "e83a762c-9592-5acf-82bb-874a6d9eb902"
+   strings:
+      $ps1 = "-NoP -C Get-Process|Sort CPU" ascii wide
+      $ps2 = "-NoP -C Get-Service|?{$_.Status -eq" ascii wide
+      $ps3 = "-NoP -C Get-WmiObject Win32_ComputerSystem" ascii wide
+      $ps4 = "PartOfDomain,Domain,DomainRole" ascii wide
+      $ps5 = "Select -First 20 Name,Id,CPU,WS" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      3 of them
+      }
+}
+
+rule XWorm_AgentSec_Authentication {
+   meta:
+      description = "Detects XWorm AgentSec authentication secret naming convention used for C2 handshake authentication"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-v2-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "f01c77e9-a0ec-5671-b3f4-4d7ac2ff3117"
+   strings:
+      $pattern1 = /AgentSec_[0-9A-Za-z]{40,50}/ ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      $pattern1
+}
+
+rule XWorm_WebSocket_C2 {
+   meta:
+      description = "Detects .NET executables with XWorm WebSocket C2 communication pattern including heartbeat and reconnect logic"
+      license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"
+      author = "The Hunters Ledger"
+      reference = "https://pixelatedcontinuum.github.io/Threat-Intel-Reports/hunting-detections/agent-xworm-v2-exe/"
+      date = "2026-01-12"
+      family = "XWorm"
+      malware_type = "RAT"
+      id = "a624d17c-50bd-5842-805a-750b55328d5d"
+   strings:
+      $ws1 = "System.Net.WebSockets" ascii wide
+      $ws2 = "WebSocketState" ascii wide
+      $ws3 = "SendAsync" ascii wide
+      $ws4 = "ReceiveAsync" ascii wide
+      $c2_1 = "Heartbeat" ascii wide nocase
+      $c2_2 = "Reconnect" ascii wide nocase
+      $c2_3 = "Frame" ascii wide
+      $dotnet = "mscorlib" ascii wide
+   condition:
+      uint16(0) == 0x5A4D and
+      filesize < 200KB and
+      $dotnet and
+      3 of ($ws1, $ws2, $ws3, $ws4) and
+      2 of ($c2_1, $c2_2, $c2_3)
+}


### PR DESCRIPTION
This PR adds detection coverage for six RAT families analyzed during 2025–2026 open-directory campaign work. Four are entirely new to \`signature-base\`; two add complementary coverage alongside existing rules.

## Files added

| File | Rules | Family | Existing coverage? |
|---|---|---|---|
| \`yara/rat_fleetagent.yar\` | 7 | FleetAgent (FUD + Advanced) | New |
| \`yara/rat_xworm.yar\` | 9 | XWorm RAT v2.x / v5.x | New |
| \`yara/rat_pulsar.yar\` | 1 | Pulsar RAT (server.exe) | New |
| \`yara/rat_poetrat.yar\` | 3 | PoetRAT (Golang RAT) | New |
| \`yara/rat_quasar_njrat_dualrat.yar\` | 4 | Dual-RAT (Quasar + NjRAT) | Complements \`apt_quasar_rat.yar\` and \`crime_cn_campaign_njrat.yar\` |
| \`yara/rat_remcos_opendir.yar\` | 6 | Remcos RAT (OpenDir campaign) | Complements \`mal_coralwave_remcos_dropper.yar\` |

## Detection approach

Each rule combines:
- **Exact hash anchors** (SHA256/SHA1/MD5) for known samples
- **Behavioral / structural signatures** — WebSocket C2 patterns (\`Sec-WebSocket-Key\`, \`AgentSec_*\` auth strings, \`SendAsync\`/\`ReceiveAsync\`), VB6 runtime + dropper artifacts, Golang runtime markers, \`Remcos_Mutex_Inj\`, Pastebin dead-drop C2, .NET WebSocket / WebSockets framework imports, HVNC and BCrypt strings, EnableLUA UAC-bypass commands, Windows Defender masquerading paths, quad-persistence architecture (registry run key + startup LNK + scheduled task + Microsoft-named binary)
- **PE structural checks** and **filesize bounds** to constrain FP risk

## Metadata

- \`author = "The Hunters Ledger"\` on every rule
- Per-rule \`license = "CC BY-NC 4.0 - https://creativecommons.org/licenses/by-nc/4.0/"\` (preserves the original license rather than the default DRL 1.1; explicit license tag is supported per the repo README)
- Stable UUIDv5 \`id\` values (deterministic — regeneration yields the same IDs)
- \`family\` / \`malware_family\` / \`campaign\` meta where appropriate
- \`reference\` field pointing to per-family technical writeup on the public site

## Source / context

Each rule's \`reference\` field links to the original technical analysis at [pixelatedcontinuum.github.io/Threat-Intel-Reports](https://pixelatedcontinuum.github.io/Threat-Intel-Reports/), where the full reverse-engineering and behavioral characterization is documented (open-directory enumeration, sample triage, dynamic analysis). The rules were originally drafted as part of analysis batches and are being contributed here for community distribution.

## Notes

- No rule-name collisions with existing \`signature-base\` content (checked against the master branch).
- The Quasar + NjRAT and Remcos families have existing coverage in \`signature-base\`; the rules here target distinct campaigns (Pastebin dead-drop dual-RAT and the 203.159.90.147 open directory) and use disjoint rule names. Happy to consolidate or rename if a maintainer prefers.
- Open to splitting into smaller PRs (e.g., one PR per family) or addressing FP feedback from triage.