### PR TITLE
Add rule for The Gentlemen ransomware

### DIFF
--- a/yara/mal_ransom_gentlemen.yar
+++ b/yara/mal_ransom_gentlemen.yar
@@ -1,0 +1,26 @@
+
+rule MAL_RANSOM_Gentlemen_Jun26_1 {
+   meta:
+      description = "Detects The Gentlemen ransomware Windows locker (Storm-2697), a self-propagating Go-based encryptor"
+      author = "Aryu-RU"
+      reference = "https://www.microsoft.com/en-us/security/blog/2026/05/28/the-gentlemen-ransomware-dissecting-a-self-propagating-go-encryptor/"
+      date = "2026-06-16"
+      hash1 = "22b38dad7da097ea03aa28d0614164cd25fafeb1383dbc15047e34c8050f6f67"
+      hash2 = "f918535f974591ef031bd0f30a8171e3da27a6754e6426a8ba095f83195661c8"
+      score = 80
+      id = "e93ade6d-c558-426c-b8b5-c6034baf6693"
+   strings:
+      $x1 = "README-GENTLEMEN.txt" ascii      /* ransom note dropped into each encrypted directory */
+      $x2 = "gentlemen.bmp" ascii             /* wallpaper dropped to %TEMP% and set as desktop background */
+      $x3 = "gentlemen_system" ascii          /* scheduled task created for privilege escalation */
+
+      $s1 = "[+] Encryption started" ascii    /* locker console output */
+      $s2 = "Encrypt only mapped" ascii       /* '--shares' run option */
+      $s3 = "Silent mode" ascii               /* '--silent' run option */
+   condition:
+      uint16(0) == 0x5A4D and filesize < 30MB
+      and (
+         2 of ($x*)
+         or ( 1 of ($x*) and 2 of ($s*) )
+      )
+}


### PR DESCRIPTION
## Summary

New rule `MAL_RANSOM_Gentlemen_Jun26_1` for **The Gentlemen** ransomware (operators tracked by Microsoft as **Storm-2697**) — a self-propagating, Go-based Windows encryptor that spreads over SMB with harvested credentials and encrypts files using Curve25519 + XChaCha20. The family was first profiled by Trend Micro in September 2025; Microsoft's May 2026 analysis documents the self-propagating Go variant.

The rule anchors on three family-specific host artifacts that survive the Go/Garble build — the ransom note `README-GENTLEMEN.txt`, the `%TEMP%\gentlemen.bmp` wallpaper, and the `gentlemen_system` scheduled task — supported by locker console/option strings, and is gated on PE magic plus a filesize bound. The victim-specific (random 6-character) encrypted-file extension is intentionally not used as an anchor. Every match path requires at least one family-specific anchor inside a PE.

## References

- https://www.microsoft.com/en-us/security/blog/2026/05/28/the-gentlemen-ransomware-dissecting-a-self-propagating-go-encryptor/ — Microsoft Threat Intelligence
- https://www.huntress.com/blog/the-gentlemen-ransomware-defense-evasion-ttps — Huntress
- https://www.trendmicro.com/en_us/research/25/i/unmasking-the-gentlemen-ransomware.html — Trend Micro (original profile; published the locker detection strings)

## Samples (report-sourced, locker PE)

- `22b38dad7da097ea03aa28d0614164cd25fafeb1383dbc15047e34c8050f6f67` — encryptor (Microsoft)
- `f918535f974591ef031bd0f30a8171e3da27a6754e6426a8ba095f83195661c8` — `G_hlm7jj_windows_amd64.exe` (Huntress)

## Testing performed

- Compiles clean with YARA 4.5.5 (`yarac -w`, no warnings) and passes the repository syntax check.
- Condition logic verified with synthetic positive/negative/threshold files: both positive paths match; a non-PE file containing all three anchors does not match (PE-magic guard); the generic console strings without a family anchor do not match; a single anchor plus a single console string stays below threshold.
- Live-sample test not performed — the samples are not retrievable from MalwareBazaar's free API and no API key was available in this environment.
- No goodware-corpus FP test — none was available here. FP risk was assessed by string-uniqueness review: the ransom-note name and the two `gentlemen`-bearing strings are not plausibly present in goodware, and the condition never fires on the generic strings alone.

## Notes

- `score = 80` reflects family-level confidence.
- The `$s*` console/option strings are deliberately secondary (never sufficient on their own) to keep the false-positive risk minimal.
- No existing rule covers this family — the full `yara/` tree and the IOC files were checked against the family name, Storm-2697, all sample hashes, every anchor string, and the reference URLs (zero matches).
