### PR TITLE
Add rule for Showboat Linux backdoor

### DIFF
--- a/yara/mal_lnx_showboat.yar
+++ b/yara/mal_lnx_showboat.yar
@@ -1,0 +1,25 @@
+
+rule MAL_LNX_Showboat_Jun26_1 {
+   meta:
+      description = "Detects Showboat, a modular Linux (ELF x86-64) post-exploitation backdoor used by China-nexus actors against telecom providers - provides remote shell, SOCKS5 proxy, file transfer and process hiding"
+      author = "Aryu-RU"
+      reference = "https://www.lumen.com/blog/en-us/introducing-showboat-a-new-malware-family-taunts-defenses-and-targets-international-telecom-firms"
+      date = "2026-06-18"
+      score = 80
+      id = "496c5f75-c48d-4b75-b0a6-f77b94f30fdd"
+   strings:
+      $x1 = "look me, AV!" ascii            /* hardcoded XOR key applied byte-wise to decrypt the agent config */
+
+      $a1 = "_SKS_" ascii                   /* literal appended to the C2 URL by the SOCKS5 proxy function */
+      $a2 = "_MAP_" ascii                   /* literal appended to the C2 URL by the portmap/scan function */
+
+      $s1 = "SLOW_MODE_MIN_SLEEP" ascii     /* agent configuration field name */
+      $s2 = "SLOW_MODE_MAX_SLEEP" ascii     /* agent configuration field name */
+   condition:
+      uint32(0) == 0x464c457f
+      and filesize < 10MB
+      and (
+         all of ($a*)                       /* both C2-URL markers - the most reliable in-binary anchors */
+         or ( $x1 and 1 of ($a*, $s*) )     /* or the XOR-key taunt plus one corroborating string */
+      )
+}


### PR DESCRIPTION
## Summary

New rule `MAL_LNX_Showboat_Jun26_1` for **Showboat** — a modular Linux (ELF x86-64) post-exploitation backdoor first publicly documented by Lumen's Black Lotus Labs (May 2026) and used by China-nexus actors (one cluster overlaps with **Calypso** / Bronze Medley / Red Lamassu) in long-running intrusions against telecommunications providers. The agent offers a remote shell, SOCKS5 proxy, port-mapping/scanning, file transfer and process hiding, and pulls an XOR-encrypted configuration from its C2.

The primary, most-reliably-static match path is the pair of C2-URL markers the agent appends in-binary — `_SKS_` (SOCKS5 mode) and `_MAP_` (portmap mode) — with the family's cheeky hardcoded config XOR key `"look me, AV!"` plus a corroborating string as an alternative path. It is gated on ELF magic and a filesize bound. The short markers never fire alone (always required in combination or behind the unique key), and the config field names (`SLOW_MODE_MIN_SLEEP` / `SLOW_MODE_MAX_SLEEP`) are used only as secondary corroboration.

## References

- https://www.lumen.com/blog/en-us/introducing-showboat-a-new-malware-family-taunts-defenses-and-targets-international-telecom-firms — Lumen Black Lotus Labs (first public reporting; source of every string)
- https://github.com/blacklotuslabs/IOCs/blob/main/FrostArmada_IOCs.txt — Black Lotus Labs published IOCs

## Samples

Lumen published **no file hashes** for Showboat — only X.509 certificate fingerprints (e.g. `27df475626aafce2ea1548a9f35efb9ad951298c8b11a6adb3ccdfcd5170c677`) and network IOCs. The rule is therefore anchored on multiple distinctive in-binary strings rather than a hash, and no `hashN` metadata is included by design.

## Testing performed

- Compiles clean with YARA 4.5.5 (`yarac -w`, no warnings) and passes the repository syntax checks (`scripts/check-yara-syntax.sh`, `tests/syntax/check.sh`).
- Condition logic verified with synthetic positive/negative files: the `_SKS_`+`_MAP_` path matches without the key; the `key + 1 marker` and `key + config-field` paths match; a single marker alone, a `_MAP_` substring alone (e.g. `FOO_MAP_BAR`), the key alone, and a non-ELF carrying all strings each correctly do **not** match.
- No false positives across the goodware ELF binaries tested (`/bin`, `/usr/bin`, system shared libraries); a comprehensive goodware-corpus test was not performed. FP risk was otherwise assessed by string-uniqueness review: `"look me, AV!"` is a unique developer taunt and the short `_SKS_`/`_MAP_` markers are never used as a sole match condition.
- Live-sample test not performed — Lumen published no file hashes and a sample could not be obtained, so the rule was authored directly from the report. All strings are taken verbatim from the Lumen report.

## Notes

- `score = 80` reflects family-level / APT-backdoor confidence.
- The condition deliberately does **not** require the XOR key `"look me, AV!"`: a 12-byte key may be materialised as instruction immediates rather than a contiguous `.rodata` literal, so the primary path rests on the `_SKS_`/`_MAP_` URL markers (which the report describes the code appending), with the key as a strong alternative path. This favours reliable detection of real samples.
- The actor alias **Calypso** here is the China-nexus telecom intrusion set (Bronze Medley / Red Lamassu) and is unrelated to the older `Calypso APT 2019` / `Calypso Group` Windows IOC entries already present in `iocs/`.
- No existing rule covers this family — the full `yara/` tree and the IOC files were checked against the family name, all actor aliases, the C2 indicators, and every anchor string (zero matches).
