### PR TITLE
Add rules for Virtualizor compromise

### DIFF
--- a/iocs/c2-iocs.txt
+++ b/iocs/c2-iocs.txt
@@ -1931,4 +1931,8 @@ ebix.portal-career.com
 ebix-exam.com
 ebix.recruitment-flow.com
 
+# Virtualizer Compromise IOCs https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1
+cdn.nerat.cc;90
+connect.ne-rat.xyz;90
+
 # Last Line

--- a/iocs/filename-iocs.txt
+++ b/iocs/filename-iocs.txt
@@ -4583,4 +4583,9 @@ C:\\ProgramData\\Microsoft\\mcrypto\.chiper;85
 \\2FAGuard\\main\.dll;85
 \\2FAGuard\\setup\.exe\.config;85
 
+# Virtualizor Compromise IOCs https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1
+/tmp/widdow\.jar;75
+/tmp/\.vz_svc_done;75
+/etc/systemd/system/java\-jre\-update\.service;75
+
 # End

--- a/iocs/hash-iocs.txt
+++ b/iocs/hash-iocs.txt
@@ -3376,3 +3376,5 @@ aea55e42c4436236278e5692d3dcbcbe5fe6ce0b;DAEMON Tools Lite supplychain compromis
 2d4eb55b01f59c62c6de9aacba9b47267d398fe4;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
 9dbfc23ebf36b3c0b56d2f93116abb32656c42e4;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
 295ce86226b933e7262c2ce4b36bdd6c389aaaef;DAEMON Tools Lite supplychain compromise IOCs  https://securelist.com/tr/daemon-tools-backdoor/119654/
+
+b81a4e1fab9fc4e404d57224fe71e2c143aa93942bd46998789bdc944a7870c7;Virtualizor Compromise IOCs https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1

--- a/yara/apt_virtualizor_compromise_aug26.yar
+++ b/yara/apt_virtualizor_compromise_aug26.yar
@@ -5,7 +5,6 @@ rule APT_Virtualizor_Compromise_ForensicArtifacts_Aug26 {
       date = "2026-08-31"
       reference = "https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1"
       score = 75
-      hash = "b81a4e1fab9fc4e404d57224fe71e2c143aa93942bd46998789bdc944a7870c7"
    strings:
       $x1 = "AAAAC3NzaC1lZDI1NTE5AAAAIP13pPAm5jmInLQYD3XNb3HwrW4cAKDcphoT4kSKrnte"
       $x2 = "/tmp/.vz_svc_done"

--- a/yara/apt_virtualizor_compromise_aug26.yar
+++ b/yara/apt_virtualizor_compromise_aug26.yar
@@ -1,0 +1,41 @@
+rule APT_Virtualizor_Compromise_ForensicArtifacts_Aug26 {
+   meta:
+      description = "Detects forensic artifacts found in a campaign against compromised hosting providers using Virtualizor software"
+      author = "Florian Roth"
+      date = "2026-08-31"
+      reference = "https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1"
+      score = 75
+      hash = "b81a4e1fab9fc4e404d57224fe71e2c143aa93942bd46998789bdc944a7870c7"
+   strings:
+      $x1 = "AAAAC3NzaC1lZDI1NTE5AAAAIP13pPAm5jmInLQYD3XNb3HwrW4cAKDcphoT4kSKrnte"
+      $x2 = "/tmp/.vz_svc_done"
+      $x3 = "/tmp/widdow.jar"
+      $x4 = "31.77.220.138:2025"  // Java connection
+
+      $sa1 = "proxyuser"
+      $sb1 = "193.32.127.248"
+   condition:
+      filesize < 5MB
+      and (
+         1 of ($x*)
+         or all of ($s*)
+      )
+}
+
+rule APT_Virtualizor_Compromise_Payload_Aug26 {
+   meta:
+      description = "Detects java based payload used in a campaign against compromised hosting providers using Virtualizor software"
+      author = "Jonathan Peters (cod3nym)"
+      date = "2026-08-31"
+      reference = "https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1"
+      hash = "b81a4e1fab9fc4e404d57224fe71e2c143aa93942bd46998789bdc944a7870c7"
+      score = 80
+   strings:
+      $s1 = "net/ikvm/clientvds/stresser/methods/impl/l4/minecraft/protocollib/" ascii
+      $s2 = "oshi/util/VirtualizationDetector" ascii
+      $s3 = "META-INF/proguard/base.proUT" ascii
+   condition:
+      uint16(0) == 0x4b50
+      and filesize < 20MB
+      and all of them
+}


### PR DESCRIPTION
Adds YARA rules and IOCs for the Virtualizor compromise reported on August 31, 2026.

The incident involved malicious Virtualizor updates delivered during a BGP hijack, resulting in root-level compromise of affected hypervisor systems.

This PR adds:

- YARA rules for known forensic artifacts and the Java payload
- C2/domain indicators
- File/path indicators
- SHA-256 of the observed payload

The indicators are based on the technical details and artifacts shared by affected hosting providers in the LowEndTalk incident thread:

https://lowendtalk.com/discussion/220625/urgent-virtualizor-compromised-31st-aug/p1

The investigation is still ongoing, so additional indicators may follow.