### PR TITLE
Add YARA rule for the BlueNoroff fake-meeting kit bundle

### DIFF
--- a/yara/apt_bluenoroff_fake_meeting_kit.yar
+++ b/yara/apt_bluenoroff_fake_meeting_kit.yar
@@ -1,0 +1,29 @@
+rule MAL_APT_BlueNoroff_FakeMeeting_JS_Kit {
+   meta:
+      author = "farbodghasemlu"
+      description = "Detects the BlueNoroff (DPRK) fake Zoom/Teams meeting ClickFix kit JavaScript bundle"
+      reference = "https://www.jumpsec.com/guides/inside-a-dprk-bluenoroff-clickfix-kit/"
+      date = "2026-09-01"
+      score = 75
+      id = "a48d4cb6-e955-4aa8-8bb8-ebce684987f2"
+      hash1 = "e2ac3ee6366d38ae0f87d72cec86044516d41f8bbfbc853d0275315cfc598f6e"
+      hash2 = "0e69a1cc83d85f4c9fe0c6845b7db007435613c4353260685077186073006233"
+      hash3 = "423fef87e61c62b8a07e21f501114881858c8a90464a01db44d94066791e177c"
+   strings:
+      $tok  = "sahfuehf29385hsdfuiewhf" ascii wide
+      $pwd  = "9jXK14VFM8fObdKxfkake8tD" ascii wide
+      $mod1 = "executeLinkFromDownUrl" ascii wide
+      $mod2 = "refreshRoomExecuteUrlFromDownUrl" ascii wide
+      $mod3 = "room-down-url" ascii wide
+      $env1 = "MEETING_SDK_VERSION" ascii wide
+      $env2 = "AUTH_API_TOKEN" ascii wide
+      $ha   = "host-action" ascii wide
+      $ms   = "mediasoup" ascii wide
+   condition:
+      filesize > 100KB and filesize < 8MB
+      and (
+         any of ($tok, $pwd)
+         or ( 2 of ($mod*) and 1 of ($env*) )
+         or ( all of ($env*) and $ha and $ms )
+      )
+}


### PR DESCRIPTION
# Add YARA rule for the BlueNoroff fake-meeting ClickFix kit bundle

This adds one YARA rule, `MAL_APT_BlueNoroff_FakeMeeting_JS_Kit`, for the
JavaScript bundle of the BlueNoroff (DPRK, a Lazarus subgroup) fake Zoom/Teams
meeting ClickFix kit that was active in August 2026.

## What it detects

The kit serves a working video-conferencing single-page app whose bundle
contains a hardcoded `AUTH_API_TOKEN` (`sahfuehf29385hsdfuiewhf`), a reused fake
meeting passcode (`9jXK14VFM8fObdKxfkake8tD`), and the kit's own module names
(`executeLinkFromDownUrl`, `refreshRoomExecuteUrlFromDownUrl`, `room-down-url`,
`host-action`) alongside `MEETING_SDK_VERSION` and `mediasoup`. The rule fires on
either high-fidelity string on its own, or on combinations of the module and
environment strings, with a filesize band around the observed bundles.

Matched against three collected bundles (SHA-256 in the rule meta). Confirmed to
match a re-downloaded copy of one of them.

## Prior work and scope

Small addition to work already published by JUMPSEC ("Inside a DPRK BlueNoroff
ClickFix Kit", 2026-07-24) and Arctic Wolf (May 2026). Full analysis and
indicators: https://github.com/farbodghasemlu/bluenoroff-fake-meeting-kit

The existing `crime_bluenoroff_pos.yar` covers a different BlueNoroff family
(point-of-sale malware) and does not overlap with this bundle.

## False positives

The `AUTH_API_TOKEN` value and the passcode are near-unique. The module strings
are specific to this kit. Broad false positives are unlikely. Note that the
XAMPP server banner on the kit's lure hosts
(`Apache/2.4.58 (Win64) OpenSSL/3.1.3 PHP/8.2.12`) is not part of this rule,
because on its own it matches more than 3,300 unrelated hosts.

## Validation

Compiles clean with `yara -w` (tested with libyara via yara-python 4.5.4, no
warnings). Functional match confirmed against a real kit bundle.
